### PR TITLE
Add type hint review summary

### DIFF
--- a/TYPE_HINT_REVIEW.md
+++ b/TYPE_HINT_REVIEW.md
@@ -1,0 +1,37 @@
+# Type Hint Review Findings
+
+This report documents issues identified in recently auto-fixed type hints and annotations.
+
+## Summary
+
+- `StrategyTrackingMixin.get_strategy_pnl_summary` returns `dict[str, Any]`, obscuring the structure of summary data and allowing unexpected keys or types.
+- `extract_order_details_from_alpaca_order` accepts an untyped `order`, leaving runtime attributes unchecked.
+- `StrategyOrderTracker` uses broad `dict[str, Any]` in `_apply_order_history_limit` and `get_summary_for_email`, meaning the expected schema of persisted order data and summary reports isn’t enforced.
+- `generate_multi_strategy_signals` returns `tuple[Any, ...]`, hiding the concrete types of manager, signal map, and portfolio allocation; callers must infer the tuple layout manually.
+- `_prepare_limit_order` returns `tuple[Any, ...]` even though it actually yields `(LimitOrderRequest | None, str | None)`, losing both parameter and conversion information typing.
+- `wait_for_order_completion` suppresses `no-any-return` for `_use_existing_websocket` and `_create_new_websocket`, because those helpers lack explicit return types, weakening static checks.
+- `EmailConfig.get_config` caches configuration in an attribute with an implicit `Any`, risking incorrect reuse if the tuple structure changes.
+- Several KLM worker variants silence assignment errors by forcing tuples with incompatible first elements (symbol string vs. allocation dict), masking type divergences.
+- Protocols in `TradingEngine` rely on `dict[str, Any]` for account and position data, leaving critical fields untyped.
+- `cast(TimeFrame, timeframe)` converts arbitrary inputs to `TimeFrame` without validation if the mapping misses a key, potentially hiding invalid values.
+
+## Recommendations
+
+| Location | Issue | Recommendation |
+|----------|-------|---------------|
+| `tracking/integration.get_strategy_pnl_summary` | `dict[str, Any]` return hides structure | Define a `TypedDict` or dataclass describing P&L summary fields. |
+| `tracking/integration.extract_order_details_from_alpaca_order` | `order` untyped | Introduce a `Protocol` with required order attributes or import Alpaca's order model for static typing. |
+| `tracking/strategy_order_tracker._apply_order_history_limit` & `get_summary_for_email` | Broad `dict[str, Any]` | Create `TypedDict` for order-history JSON and summary report to enforce schema. |
+| `main.generate_multi_strategy_signals` | `tuple[Any, ...]` return | Use `tuple[MultiStrategyManager, dict[StrategyType, StrategySignal], dict[str, float]]` (define `StrategySignal` via `TypedDict` or dataclass). |
+| `utils/limit_order_handler._prepare_limit_order` | `tuple[Any, ...]` return | Specify `tuple[LimitOrderRequest | None, str | None]` and propagate through calling code. |
+| `utils/websocket_order_monitor` | `no-any-return` ignores | Annotate `_use_existing_websocket` and `_create_new_websocket` to return `dict[str, str]` or a dedicated `TypedDict`. |
+| `EmailConfig` | `_config_cache` typed implicitly as `Any` | Declare `self._config_cache: tuple[str, int, str, str, str] | None` and remove ignore. |
+| `variant_1280_26` & `variant_530_18` | Tuple assignments with incompatible types | Widen the tuple type or introduce a small result dataclass with explicit fields. |
+| `execution/trading_engine` protocols | `dict[str, Any]` for complex structures | Model account info and position data with `TypedDict` or dataclasses to validate required fields and types. |
+| `core/data/data_provider` | Unchecked `cast(TimeFrame, timeframe)` | Define parameter as `TimeFrame | str` and convert via mapping before request creation; avoid `cast` by returning `TimeFrame` from helper. |
+
+## Additional Observations
+
+- Many utility and reporting functions rely on `dict[str, Any]` or `list[dict[str, Any]]`. Converting these to well-defined dataclasses or `TypedDict` structures would improve type safety and clarity.
+- Removing `type: ignore` directives will surface real type mismatches early. When necessary, refine function signatures rather than suppressing warnings.
+


### PR DESCRIPTION
## Summary
- add a markdown report summarizing issues and recommendations for recent type hint changes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68911880a0bc833389f01ea056987ecf