### PR TITLE
Add trading bot failure-mode analysis documentation

### DIFF
--- a/failure-mode-analysis.md
+++ b/failure-mode-analysis.md
@@ -1,0 +1,258 @@
+# Trading Bot Failure-Mode Analysis
+
+## Trading Logic / Market Scenarios
+1. **Indicator miscalculation from missing or stale market data**  
+   - **How it could occur:** API outages, incomplete S3 uploads, or data pulled for the wrong symbol/timeframe.  
+   - **Potential impact:** Incorrect signals, leading to trades taken/avoided at the wrong time.  
+   - **Detection/Testing:** Cross-validate with multiple data sources; unit tests with synthetic missing-bar scenarios; alert on data gaps.
+
+2. **Timezone mismatches and schedule misalignments**  
+   - **How it could occur:** EventBridge set to UTC but logic assumes local market time.  
+   - **Potential impact:** Orders sent when the market is closed or missed during open hours.  
+   - **Detection/Testing:** Automated tests verifying conversions around DST/holidays; monitor broker "market open/closed" flags before trading.
+
+3. **Holiday/early close or unscheduled market halts**  
+   - **How it could occur:** Calendar not updated or market shut due to volatility or regulatory action.  
+   - **Potential impact:** Orders rejected or stuck pending, possible missed exits.  
+   - **Detection/Testing:** Integrate a real-time market status check; simulate trading around known holiday schedules.
+
+4. **Price gaps and extreme volatility**  
+   - **How it could occur:** Overnight gaps or flash crashes make indicators inaccurate at the open.  
+   - **Potential impact:** Entering positions at unfavorable prices, stop-losses skipped or executed immediately.  
+   - **Detection/Testing:** Stress-test strategy on historical gap scenarios; runtime checks comparing last close vs. open.
+
+5. **Tick-size and rounding errors**  
+   - **How it could occur:** Using float math on instruments with minimum tick requirements.  
+   - **Potential impact:** Broker rejects orders or adjusts price/size unexpectedly.  
+   - **Detection/Testing:** Use Decimal for price calculations; unit tests covering various tick sizes.
+
+6. **Partial fills and duplicate position logic**  
+   - **How it could occur:** Strategy assumes full fills; retry logic re-sends orders.  
+   - **Potential impact:** Over/under positions, incorrect portfolio allocation.  
+   - **Detection/Testing:** Simulate partial-fill responses; monitor open orders and reconcile before reordering.
+
+7. **Hard-coded assumptions about instrument tradability**  
+   - **How it could occur:** Strategy assumes all symbols are marginable or shortable.  
+   - **Potential impact:** Rejected orders, missed signals.  
+   - **Detection/Testing:** Query broker metadata before placing trades; add tests for restricted symbols.
+
+8. **Floating-point precision in moving average crossover**  
+   - **How it could occur:** Minimal difference between long/short averages leads to jittering signals.  
+   - **Potential impact:** Thrashing in and out of positions.  
+   - **Detection/Testing:** Introduce hysteresis or tolerance in crossover logic; backtest for edge cases around zero crossings.
+
+9. **Improper stop-loss or risk rules**  
+   - **How it could occur:** Stop prices calculated off stale data; stop-loss not attached.  
+   - **Potential impact:** Runaway losses or unprotected positions.  
+   - **Detection/Testing:** Unit tests for risk-calculation boundaries; monitor for orders lacking protective stops.
+
+10. **State not reset between runs**  
+    - **How it could occur:** Lambda reuses container; global variables hold stale signals.  
+    - **Potential impact:** Acting on previous session’s data.  
+    - **Detection/Testing:** Initialize state inside handler; unit tests using warm/cold start scenarios.
+
+## Code Quality / Bugs
+1. **Unhandled exceptions or failing imports**  
+   - **How it could occur:** Missing try/except around critical logic, or missing dependencies in deployment package.  
+   - **Potential impact:** Lambda exits early, leaving no trade placed or order partially sent.  
+   - **Detection/Testing:** Exception-level logging; run unit tests with fault injection (missing modules, forced errors).
+
+2. **Race conditions with concurrent Lambdas**  
+   - **How it could occur:** EventBridge misfires or manual retries run in parallel, both updating S3/state simultaneously.  
+   - **Potential impact:** Portfolio desync, double trades.  
+   - **Detection/Testing:** Use concurrency locks (S3 object locks, DynamoDB conditional writes); integration tests with parallel invocations.
+
+3. **Improper float-to-decimal conversions for order quantities**  
+   - **How it could occur:** `float` to `int` casting drops fractional shares but logic assumes full size.  
+   - **Potential impact:** Undersized trades, incomplete hedging.  
+   - **Detection/Testing:** Enforce Decimal across calculations; unit tests for boundary sizes.
+
+4. **Configuration missing or misread**  
+   - **How it could occur:** Environment variables not set, CloudFormation parameters misnamed.  
+   - **Potential impact:** Bot starts with default placeholders, trading wrong symbols or accounts.  
+   - **Detection/Testing:** Startup validation with explicit failures on missing config; CI tests using sample CloudFormation template.
+
+5. **Logging failures**  
+   - **How it could occur:** Logging library misconfigured or rate-limited; CloudWatch ingestion errors.  
+   - **Potential impact:** Silent operations; post-mortem hard.  
+   - **Detection/Testing:** Watchdog verifying log entries after each run; integration tests with logging off to ensure fallback.
+
+6. **Poor error-handling of retries**  
+   - **How it could occur:** Retry loops without backoff or idempotency checks.  
+   - **Potential impact:** Duplicate orders, rate limit breaches.  
+   - **Detection/Testing:** Unit tests with mock retries; use idempotency tokens; monitor for repeated order IDs.
+
+7. **Out-of-date dependencies or breaking changes**  
+   - **How it could occur:** Deployment locked to old library versions; API library adds new mandatory fields.  
+   - **Potential impact:** Runtime exceptions or incorrect request serialization.  
+   - **Detection/Testing:** Dependabot/Snyk in CI; regression tests before deployment.
+
+8. **Memory or file descriptor leaks**  
+   - **How it could occur:** Persistent connections not closed, growing S3 temp files.  
+   - **Potential impact:** Lambda hitting memory limit or slow subsequent invocations.  
+   - **Detection/Testing:** Profiling with repeated warm invocations; runtime metrics alarm when memory usage spikes.
+
+## API and Broker-Side Issues
+1. **API rate limits or throttling**  
+   - **How it could occur:** Multiple indicator requests or rapid order submissions.  
+   - **Potential impact:** 429 errors, delayed or missed orders.  
+   - **Detection/Testing:** Implement exponential backoff; test with rate-limit mocks; monitor broker-provided rate-limit headers.
+
+2. **Network latency or connectivity outages**  
+   - **How it could occur:** AWS region network blips; VPC misconfiguration.  
+   - **Potential impact:** Timeout errors, delayed order entry.  
+   - **Detection/Testing:** Use retries with backoff; CloudWatch metrics on timeout counts; synthetic network tests.
+
+3. **Broker API schema changes or deprecations**  
+   - **How it could occur:** New mandatory fields, changed response formats.  
+   - **Potential impact:** Serialization errors, ignored orders.  
+   - **Detection/Testing:** Version pinning; contract tests against sandbox; monitor release notes.
+
+4. **Authentication or session expiration**  
+   - **How it could occur:** Secret rotation not propagated, JWT tokens expired.  
+   - **Potential impact:** Orders rejected, API returns 401/403.  
+   - **Detection/Testing:** Pre-run auth check; scheduled credential refresh; alerts on auth failures.
+
+5. **Order acknowledgments lost or out of order**  
+   - **How it could occur:** Broker acknowledges but network drops response; async callbacks not handled.  
+   - **Potential impact:** Bot resends, causing duplicate orders.  
+   - **Detection/Testing:** Use client-side IDs; compare open orders before sending new ones; simulate lost ACKs.
+
+6. **Partial fills not fully reconciled by broker**  
+   - **How it could occur:** Broker reports partial fill; bot assumes complete.  
+   - **Potential impact:** Remaining shares unaccounted, hedge incomplete.  
+   - **Detection/Testing:** Poll order status until filled or canceled; tests with simulated partial fills.
+
+7. **Margin or buying-power constraints**  
+   - **How it could occur:** Broker rejects order because of insufficient funds or unsettled cash.  
+   - **Potential impact:** Trade not placed or auto-liquidation.  
+   - **Detection/Testing:** Check account balances before orders; test with account mock exposing varying margin.
+
+8. **Broker outages or maintenance windows**  
+   - **How it could occur:** API down; scheduled upgrades.  
+   - **Potential impact:** Bot cannot trade; orders fail.  
+   - **Detection/Testing:** Monitor broker status API/heartbeat; fallback or disable trading during maintenance windows.
+
+## AWS Infrastructure and Hosting Issues
+1. **Lambda cold starts and slow initialization**  
+   - **How it could occur:** Infrequent invocations, large deployment package.  
+   - **Potential impact:** Delayed execution; may miss narrow trading windows.  
+   - **Detection/Testing:** Keep Lambdas warm via periodic triggers; monitor duration metrics.
+
+2. **Lambda hitting execution time limit**  
+   - **How it could occur:** Complex indicator calculations or slow API responses exceed max runtime.  
+   - **Potential impact:** Trade not placed, partial computation.  
+   - **Detection/Testing:** Benchmark; instrument step-level timing; alarm when duration approaches timeout.
+
+3. **EventBridge misconfiguration or failed trigger**  
+   - **How it could occur:** Disabled rule, wrong cron expression, target removed.  
+   - **Potential impact:** Bot never runs.  
+   - **Detection/Testing:** EventBridge rule health checks; CloudWatch metrics on invocations; test schedule in non-prod.
+
+4. **IAM permission errors**  
+   - **How it could occur:** Lambda role missing `secretsmanager:GetSecretValue` or `s3:GetObject`.  
+   - **Potential impact:** Crashes retrieving config/data.  
+   - **Detection/Testing:** IAM policy linting; integration tests with minimal role; alert on AccessDenied.
+
+5. **S3 access or region mismatch**  
+   - **How it could occur:** Bucket in different region, wrong ARN.  
+   - **Potential impact:** State cannot be read/written; data loss.  
+   - **Detection/Testing:** Validate S3 region in CloudFormation; run pre-deploy integration tests for bucket access.
+
+6. **Secrets Manager throttling or unavailability**  
+   - **How it could occur:** Many Lambdas simultaneously fetch secrets, hitting limit.  
+   - **Potential impact:** Start-up failures.  
+   - **Detection/Testing:** Cache secrets locally; monitor Secrets Manager metrics; stress-test with multiple concurrent invocations.
+
+7. **CloudFormation drift or failed updates**  
+   - **How it could occur:** Manual edits outside stack; partially failed deployment.  
+   - **Potential impact:** Mismatched environments, missing resources.  
+   - **Detection/Testing:** Use `cfn-drift-detection`; CI pipeline verifying stack status before trading.
+
+8. **VPC or security-group misconfiguration**  
+   - **How it could occur:** Lambda placed in VPC without NAT, blocking outbound API calls.  
+   - **Potential impact:** Cannot reach broker or S3.  
+   - **Detection/Testing:** Network connectivity tests during deployment; CloudWatch metrics for ENI errors.
+
+9. **AWS service outages or regional failures**  
+   - **How it could occur:** Regional S3/Lambda outage.  
+   - **Potential impact:** Bot offline.  
+   - **Detection/Testing:** Multi-region failover design; monitor AWS Health Dashboard; practice regional failover drills.
+
+10. **CloudWatch log retention or quota limits**  
+    - **How it could occur:** Log group reaches quota; new logs dropped.  
+    - **Potential impact:** Unable to debug failures.  
+    - **Detection/Testing:** Set retention policies; monitor `Throttling` metrics; auto-prune old logs.
+
+## Data Integrity and Persistence
+1. **S3 writes failing or partial**  
+   - **How it could occur:** Network errors mid-upload; concurrent writes overwriting.  
+   - **Potential impact:** Lost signals, portfolio state drift.  
+   - **Detection/Testing:** Use S3 `ETag` checks or versioning; integration tests with simulated network interruptions.
+
+2. **Eventual consistency leading to stale reads**  
+   - **How it could occur:** Immediately reading after write in different Lambda invocation.  
+   - **Potential impact:** Trading decisions based on old state.  
+   - **Detection/Testing:** Add retries with backoff for read-after-write; validate version/timestamp.
+
+3. **Corrupted or malformed data in S3**  
+   - **How it could occur:** Incomplete JSON, wrong schema.  
+   - **Potential impact:** Parsing errors or defaulting to incorrect values.  
+   - **Detection/Testing:** Schema validation upon read; unit tests verifying schema evolution.
+
+4. **Portfolio desynchronization**  
+   - **How it could occur:** Broker fills but S3 state not updated (Lambda crash after placing order).  
+   - **Potential impact:** Bot believes flat while holding positions.  
+   - **Detection/Testing:** Reconcile with broker account each run; tests simulating mid-run crashes.
+
+5. **State not persisted across sessions**  
+   - **How it could occur:** Assumes Lambda environment persistent but container recycled.  
+   - **Potential impact:** Loss of signal history or open orders.  
+   - **Detection/Testing:** Store critical state externally; run repeated cold starts in tests.
+
+6. **Integer/float overflow or precision drift in stored data**  
+   - **How it could occur:** Aggregating P&L or position size repeatedly without precision control.  
+   - **Potential impact:** Long-term drift in allocation or risk numbers.  
+   - **Detection/Testing:** Use Decimal; regression tests over large simulated datasets.
+
+7. **Unstructured or excessive log growth**  
+   - **How it could occur:** Verbose logging of market data to S3.  
+   - **Potential impact:** High storage costs, slower reads.  
+   - **Detection/Testing:** Enforce log rotation/archival; unit tests verifying logger filters.
+
+## Security and Secrets Management
+1. **Secrets not rotated or outdated**  
+   - **How it could occur:** Long-lived API keys in Secrets Manager never updated.  
+   - **Potential impact:** Credentials compromised or invalid.  
+   - **Detection/Testing:** Implement rotation policies; test retrieval of newly rotated secrets.
+
+2. **Secrets exposed in logs or exception traces**  
+   - **How it could occur:** Printing exception objects containing keys; debug logging.  
+   - **Potential impact:** Leakage via CloudWatch.  
+   - **Detection/Testing:** Static analysis for logging statements; runtime scans for key patterns.
+
+3. **IAM roles overly permissive or misused**  
+   - **How it could occur:** Lambda role allows broad S3 or Secrets access.  
+   - **Potential impact:** Escalation if compromised.  
+   - **Detection/Testing:** IAM policy linting, least-privilege reviews; unit tests verifying denied actions for disallowed resources.
+
+4. **Secrets Manager access failures**  
+   - **How it could occur:** Misconfigured resource policy or VPC endpoint restrictions.  
+   - **Potential impact:** Lambda fails to fetch credentials, leading to runtime errors.  
+   - **Detection/Testing:** Integration test retrieving secrets in deployment; CloudWatch alarms on `AccessDenied`.
+
+5. **Unencrypted data at rest or in transit**  
+   - **How it could occur:** S3 bucket without encryption, HTTP instead of HTTPS.  
+   - **Potential impact:** Data interception or regulatory violation.  
+   - **Detection/Testing:** CloudFormation enforcing encryption; security scans; run tests that fail without HTTPS.
+
+6. **Compromised dependencies or container**  
+   - **How it could occur:** Using third-party libraries with vulnerabilities.  
+   - **Potential impact:** Malicious code execution or data exfiltration.  
+   - **Detection/Testing:** Use dependency scanning (e.g., pip-audit); signature verification for deployment artifacts.
+
+7. **Insufficient monitoring or alerting on security events**  
+   - **How it could occur:** No alarms for failed login attempts, unusual API calls.  
+   - **Potential impact:** Breach goes unnoticed.  
+   - **Detection/Testing:** Configure CloudTrail/GuardDuty; test alerts with simulated unauthorized actions.
+


### PR DESCRIPTION
## Summary
- document exhaustive failure-mode analysis for AWS Lambda-based trading bot

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689188e750cc8333b05de292036517de