### PR TITLE
Remove deprecated methods per cleanup plan

### DIFF
--- a/the_alchemiser/execution/portfolio_rebalancer.py
+++ b/the_alchemiser/execution/portfolio_rebalancer.py
@@ -213,8 +213,8 @@ class PortfolioRebalancer:
                     Console().print(
                         f"[yellow]Liquidating {symbol} (not in target portfolio)[/yellow]"
                     )
-                    # Use Alpaca's liquidate_position API instead of manual calculation
-                    order_id = self.order_manager.liquidate_position(symbol)
+                    # Use direct liquidation via order manager
+                    order_id = self.order_manager.execute_liquidation(symbol)
                     if order_id:
                         # Estimate value for tracking purposes
                         price = self.bot.get_current_price(symbol)
@@ -265,7 +265,7 @@ class PortfolioRebalancer:
                 from rich.console import Console
 
                 Console().print(f"[yellow]Liquidating {symbol} (target allocation: 0%)[/yellow]")
-                order_id = self.order_manager.liquidate_position(symbol)
+                order_id = self.order_manager.execute_liquidation(symbol)
                 if order_id:
                     # Estimate value for tracking purposes
                     qty = position_qty  # Use the already calculated position_qty

--- a/the_alchemiser/utils/asset_info.py
+++ b/the_alchemiser/utils/asset_info.py
@@ -109,9 +109,6 @@ class FractionabilityDetector:
         """
         Determine if an asset supports fractional shares using Alpaca API.
 
-        This is the authoritative method that should be used instead of
-        is_likely_non_fractionable() when possible.
-
         Args:
             symbol: Stock symbol to check
             use_cache: Whether to use cached results
@@ -162,23 +159,6 @@ class FractionabilityDetector:
         # Conservative approach: assume fractionable unless proven otherwise
         # This is safer since most assets are fractionable according to API testing
         return True
-
-    def is_likely_non_fractionable(self, symbol: str) -> bool:
-        """
-        Legacy method for backward compatibility.
-
-        DEPRECATED: Use is_fractionable() instead for API-based results.
-
-        Args:
-            symbol: Stock symbol to check
-
-        Returns:
-            True if likely non-fractionable, False otherwise
-        """
-        logging.warning(
-            "⚠️ is_likely_non_fractionable() is deprecated, use is_fractionable() instead"
-        )
-        return not self.is_fractionable(symbol)
 
     def get_asset_type(self, symbol: str) -> AssetType:
         """


### PR DESCRIPTION
## Summary
- drop deprecated `get_pending_orders` and validate pending orders directly
- eliminate legacy smart-execution wrappers and cleanup portfolio rebalancer
- remove obsolete fractionability helper and legacy order conversion utilities

## Testing
- `ruff check the_alchemiser/execution/alpaca_client.py the_alchemiser/execution/order_validation.py the_alchemiser/execution/portfolio_rebalancer.py the_alchemiser/execution/smart_execution.py the_alchemiser/utils/asset_info.py`
- `make test` *(fails: ModuleNotFoundError: No module named 'moto', cachetools, psutil, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_6894c4bd72708333a7769ff2d2ad9e01