### PR TITLE
Fix services package public API and Sonar undefined-name findings

### DIFF
--- a/tests/public_api/test_services_public_api.py
+++ b/tests/public_api/test_services_public_api.py
@@ -1,0 +1,24 @@
+from the_alchemiser.services import (
+    AccountService,
+    CacheManager,
+    ConfigService,
+    MarketDataClient,
+    SecretsService,
+    StreamingService,
+    TradingClientService,
+)
+
+
+def test_public_api_imports():
+    assert all(
+        obj is not None
+        for obj in (
+            AccountService,
+            CacheManager,
+            ConfigService,
+            MarketDataClient,
+            SecretsService,
+            StreamingService,
+            TradingClientService,
+        )
+    )

--- a/the_alchemiser/services/__init__.py
+++ b/the_alchemiser/services/__init__.py
@@ -1,25 +1,32 @@
-"""
-Core services for the trading system.
+"""Core services for the trading system.
 
-This package contains modularized services that replace the monolithic UnifiedDataProvider:
-- ConfigService: Configuration management
-- SecretsService: Credential management
-- MarketDataClient: Market data retrieval
-- TradingClientService: Trading operations
-- StreamingService: Real-time data streaming
-- CacheManager: Configurable caching with TTL
-- AccountService: Account and position management
+This package contains modularized services that replace the monolithic
+``UnifiedDataProvider``:
+
+* ConfigService: Configuration management
+* SecretsService: Credential management
+* MarketDataClient: Market data retrieval
+* TradingClientService: Trading operations
+* StreamingService: Real-time data streaming
+* CacheManager: Configurable caching with TTL
+* AccountService: Account and position management
 """
 
-# Note: Lazy imports to avoid circular dependencies and initialization issues
-# Import services individually as needed rather than all at once
+from .account_service import AccountService
+from .cache_manager import CacheManager
+from .config_service import ConfigService
+from .market_data_client import MarketDataClient
+from .secrets_service import SecretsService
+from .streaming_service import StreamingService
+from .trading_client_service import TradingClientService
 
 __all__ = [
-    "ConfigService",
-    "SecretsService",
-    "MarketDataClient",
-    "TradingClientService",
-    "StreamingService",
-    "CacheManager",
     "AccountService",
+    "CacheManager",
+    "ConfigService",
+    "MarketDataClient",
+    "SecretsService",
+    "StreamingService",
+    "TradingClientService",
 ]
+


### PR DESCRIPTION
## Summary
- explicitly import and re-export service classes in `the_alchemiser.services` so SonarCloud sees defined names
- add smoke test covering public service API imports

## Testing
- `poetry run ruff check . --fix` *(fails: W293, W291, etc.)*
- `poetry run mypy the_alchemiser` *(fails: 73 errors)*
- `poetry run pytest -q` *(fails: module 'the_alchemiser' has no attribute 'core')*
- `poetry run ruff check the_alchemiser/services/__init__.py tests/public_api/test_services_public_api.py --fix`
- `poetry run mypy the_alchemiser/services/__init__.py tests/public_api/test_services_public_api.py`
- `poetry run pytest tests/public_api/test_services_public_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689743f6ca788333a33f23991d1eb3a8