### PR TITLE
Fix SonarCloud findings: tautologies, dup excepts, float equality

### DIFF
--- a/scripts/phase3_summary.py
+++ b/scripts/phase3_summary.py
@@ -11,7 +11,7 @@ project_root = "/Users/joshua.moreton/Documents/GitHub/the-alchemiser"
 sys.path.insert(0, project_root)
 
 
-def main():
+def main() -> int:
     print("Enhanced services Phase 3 implementation complete!")
     print("\nServices created:")
     print("✅ OrderService - Enhanced order management with validation")
@@ -35,9 +35,9 @@ def main():
     print("4. Integration with existing codebase")
     print("5. Documentation and examples")
 
-    return True
+    return 0
 
 
 if __name__ == "__main__":
-    success = main()
-    sys.exit(0 if success else 1)
+    # Sonar: main always succeeds, propagate exit code directly
+    sys.exit(main())

--- a/tests/application/test_alpaca_client.py
+++ b/tests/application/test_alpaca_client.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+from alpaca.trading.enums import OrderSide
+
+from the_alchemiser.application.alpaca_client import AlpacaClient
+from the_alchemiser.services.exceptions import TradingClientError
+
+
+class DummyTradingClient:
+    def __init__(self, errors=None):
+        self.errors = errors or []
+        self.calls = 0
+
+    def submit_order(self, _):
+        if self.calls < len(self.errors):
+            error = self.errors[self.calls]
+            self.calls += 1
+            raise error
+        self.calls += 1
+        return SimpleNamespace(id="1")
+
+
+class DummyAssetHandler:
+    def __init__(self):
+        self.fallback_called = False
+
+    def prepare_market_order(self, *args, **kwargs):
+        return object(), ""
+
+    def handle_fractionability_error(self, *args, **kwargs):
+        self.fallback_called = True
+        return object(), "converted"
+
+
+class DummyPositionManager:
+    def validate_buying_power(self, *args, **kwargs):
+        return True, ""
+
+    def validate_sell_position(self, *args, **kwargs):
+        return True, 1, ""
+
+
+class DummyOrderMonitor:
+    pass
+
+
+class DummyPricingHandler:
+    pass
+
+
+class DummyWebSocketManager:
+    pass
+
+
+def _client(trading_client):
+    client = AlpacaClient.__new__(AlpacaClient)
+    client.trading_client = trading_client
+    client.asset_handler = DummyAssetHandler()
+    client.position_manager = DummyPositionManager()
+    client.order_monitor = DummyOrderMonitor()
+    client.limit_order_handler = None
+    client.pricing_handler = DummyPricingHandler()
+    client.websocket_manager = DummyWebSocketManager()
+    client.validate_buying_power = False
+    client.cancel_all_orders = lambda symbol: None
+    client.get_current_positions = lambda: {}
+    return client
+
+
+def test_place_market_order_insufficient_buying_power():
+    trading_client = DummyTradingClient([TradingClientError("insufficient buying power")])
+    client = _client(trading_client)
+    result = client.place_market_order("AAPL", OrderSide.BUY, qty=1, cancel_existing=False)
+    assert result is None
+
+
+def test_place_market_order_fractionability():
+    error = TradingClientError("not fractionable")
+    trading_client = DummyTradingClient([error])
+    client = _client(trading_client)
+    result = client.place_market_order("AAPL", OrderSide.BUY, qty=1, cancel_existing=False)
+    assert result == "1"
+    assert client.asset_handler.fallback_called

--- a/tests/application/test_trading_engine.py
+++ b/tests/application/test_trading_engine.py
@@ -1,0 +1,46 @@
+from rich.panel import Panel
+
+from the_alchemiser.application.trading_engine import TradingEngine
+from the_alchemiser.application.types import MultiStrategyExecutionResult
+
+
+def _account_info() -> dict:
+    return {
+        "account_id": "1",
+        "equity": 0.0,
+        "cash": 0.0,
+        "buying_power": 0.0,
+        "day_trades_remaining": 0,
+        "portfolio_value": 0.0,
+        "last_equity": 0.0,
+        "daytrading_buying_power": 0.0,
+        "regt_buying_power": 0.0,
+        "status": "ACTIVE",
+    }
+
+
+def test_display_multi_strategy_summary_prints_orders_table(monkeypatch):
+    engine = TradingEngine.__new__(TradingEngine)
+    engine.paper_trading = True
+    engine.ignore_market_hours = False
+
+    execution_result = MultiStrategyExecutionResult(
+        success=True,
+        strategy_signals={},
+        consolidated_portfolio={"AAPL": 0.5},
+        orders_executed=[],
+        account_info_before=_account_info(),
+        account_info_after=_account_info(),
+        execution_summary={},
+    )
+
+    printed = []
+
+    def fake_print(self, obj=None, *args, **kwargs):
+        printed.append(obj)
+
+    monkeypatch.setattr("rich.console.Console.print", fake_print, raising=False)
+
+    engine.display_multi_strategy_summary(execution_result)
+
+    assert isinstance(printed[3], Panel)

--- a/tests/interface/cli/test_dashboard_utils.py
+++ b/tests/interface/cli/test_dashboard_utils.py
@@ -1,0 +1,12 @@
+from the_alchemiser.interface.cli.dashboard_utils import extract_portfolio_metrics
+
+
+def test_extract_portfolio_metrics_daily_pl():
+    account_info = {
+        "equity": 1000,
+        "cash": 500,
+        "portfolio_history": {"profit_loss": [1, 2, 3], "profit_loss_pct": [0.01, 0.02, 0.03]},
+    }
+    metrics = extract_portfolio_metrics(account_info)
+    assert metrics["daily_pl"] == 3
+    assert metrics["daily_pl_percent"] == 3.0

--- a/tests/scripts/test_phase3_summary.py
+++ b/tests/scripts/test_phase3_summary.py
@@ -1,0 +1,5 @@
+from scripts.phase3_summary import main
+
+
+def test_phase3_main_returns_zero():
+    assert main() == 0

--- a/tests/services/enhanced/test_trading_service_manager.py
+++ b/tests/services/enhanced/test_trading_service_manager.py
@@ -1,0 +1,13 @@
+import logging
+from types import SimpleNamespace
+
+from the_alchemiser.services.enhanced.trading_service_manager import TradingServiceManager
+
+
+def test_close_position_tolerance(monkeypatch):
+    manager = TradingServiceManager.__new__(TradingServiceManager)
+    manager.logger = logging.getLogger(__name__)
+    manager.orders = SimpleNamespace(liquidate_position=lambda symbol: "abc123")
+
+    result = manager.close_position("AAPL", percentage=100.0000000001)
+    assert result == {"success": True, "order_id": "abc123"}

--- a/tests/utils/test_num.py
+++ b/tests/utils/test_num.py
@@ -1,0 +1,23 @@
+import math
+
+import numpy as np
+
+from the_alchemiser.utils.num import floats_equal
+
+
+def test_floats_equal_basic():
+    assert floats_equal(0.1 + 0.2, 0.3)
+    assert floats_equal(0.1, 0.10000000005)
+    assert not floats_equal(0.1, 0.1001)
+
+
+def test_floats_equal_nan():
+    assert not floats_equal(math.nan, math.nan)
+
+
+def test_floats_equal_numpy():
+    arr1 = np.array([0.1, 0.2])
+    arr2 = np.array([0.1, 0.2 + 1e-10])
+    assert floats_equal(arr1, arr2)
+    arr3 = np.array([0.1, 0.2 + 1e-6])
+    assert not floats_equal(arr1, arr3)

--- a/the_alchemiser/application/alpaca_client.py
+++ b/the_alchemiser/application/alpaca_client.py
@@ -281,12 +281,12 @@ class AlpacaClient:
                 logging.info(f"Market order placed for {symbol}: {order_id}")
                 return order_id
 
-            except Exception as order_error:
-                # Check for insufficient buying power error specifically
+            except (TradingClientError, ValueError, AttributeError) as order_error:
+                # Sonar: consolidate exception handling
                 error_msg = str(order_error)
+
                 if "insufficient buying power" in error_msg.lower():
                     logging.error(f"❌ Insufficient buying power for {symbol}: {error_msg}")
-                    # Try to extract the actual buying power from the error
                     try:
                         import json
 
@@ -303,13 +303,6 @@ class AlpacaClient:
                         logging.error("❌ Could not parse buying power details from error")
                     return None
 
-                # Re-raise for other exception types to be handled by the next except block
-                raise order_error
-
-            except (TradingClientError, ValueError, AttributeError) as order_error:
-                error_msg = str(order_error)
-
-                # Handle fractionability errors using asset handler
                 if "not fractionable" in error_msg.lower() and qty is not None:
                     fallback_order, conversion_info = (
                         self.asset_handler.handle_fractionability_error(
@@ -335,9 +328,29 @@ class AlpacaClient:
                             f"❌ Fallback order also failed for {symbol}: {fallback_error}"
                         )
                         return None
-                else:
-                    # Re-raise the original error if it's not a fractionability issue
-                    raise order_error
+
+                raise
+
+            except Exception as order_error:
+                error_msg = str(order_error)
+                if "insufficient buying power" in error_msg.lower():
+                    logging.error(f"❌ Insufficient buying power for {symbol}: {error_msg}")
+                    try:
+                        import json
+
+                        if hasattr(order_error, "text"):
+                            error_data = json.loads(order_error.text)
+                        else:
+                            error_data = json.loads(error_msg.split('{"')[1].split("}")[0] + "}")
+                        actual_buying_power = error_data.get("buying_power", "unknown")
+                        cost_basis = error_data.get("cost_basis", "unknown")
+                        logging.error(
+                            f"❌ Order cost: ${cost_basis}, Available buying power: ${actual_buying_power}"
+                        )
+                    except Exception:
+                        logging.error("❌ Could not parse buying power details from error")
+                    return None
+                raise
 
         except (ConnectionError, TimeoutError, OSError) as e:
             logging.error(f"Network error placing market order for {symbol}: {e}")

--- a/the_alchemiser/application/trading_engine.py
+++ b/the_alchemiser/application/trading_engine.py
@@ -779,7 +779,7 @@ class TradingEngine:
         return build_portfolio_state_data(target_portfolio, account_info, current_positions)
 
     def _trigger_post_trade_validation(
-        self, strategy_signals: dict[StrategyType, Any], orders_executed: list[dict[str, Any]]
+        self, strategy_signals: dict[StrategyType, Any], orders_executed: Any
     ) -> None:
         """
         Trigger post-trade technical indicator validation for live trading.
@@ -793,7 +793,9 @@ class TradingEngine:
         try:
             # Enhanced order validation
             if not isinstance(orders_executed, list):
-                logging.error(f"❌ orders_executed must be a list, got {type(orders_executed)}")
+                logging.error(
+                    f"❌ orders_executed must be a list, got {type(orders_executed)}"
+                )
                 return
 
             validated_symbols = set()
@@ -802,7 +804,9 @@ class TradingEngine:
             # Validate each order and extract symbols
             for i, order in enumerate(orders_executed):
                 if not isinstance(order, dict):
-                    invalid_orders.append(f"Order {i}: Expected dict, got {type(order)}")
+                    invalid_orders.append(
+                        f"Order {i}: Expected dict, got {type(order)}"
+                    )
                     continue
 
                 symbol = order.get("symbol")
@@ -1131,10 +1135,8 @@ class TradingEngine:
         console.print(portfolio_table)
         console.print()
 
-        if isinstance(orders_table, Table):
-            console.print(orders_table)
-        else:
-            console.print(orders_table)
+        # Sonar: collapse redundant type check
+        console.print(orders_table)
         console.print()
 
         # Display closed P&L table if available

--- a/the_alchemiser/interface/cli/dashboard_utils.py
+++ b/the_alchemiser/interface/cli/dashboard_utils.py
@@ -68,7 +68,7 @@ def extract_portfolio_metrics(account_info: dict[str, Any]) -> dict[str, float]:
         profit_loss = portfolio_history.get("profit_loss", [])
         profit_loss_pct = portfolio_history.get("profit_loss_pct", [])
         if profit_loss:
-            latest_pl = profit_loss[-1] if profit_loss else 0
+            latest_pl = profit_loss[-1]  # Sonar: remove tautology
             latest_pl_pct = profit_loss_pct[-1] if profit_loss_pct else 0
             portfolio_metrics.update(
                 {"daily_pl": float(latest_pl), "daily_pl_percent": float(latest_pl_pct) * 100}

--- a/the_alchemiser/services/enhanced/trading_service_manager.py
+++ b/the_alchemiser/services/enhanced/trading_service_manager.py
@@ -6,6 +6,7 @@ from the_alchemiser.services.enhanced.account_service import AccountService
 from the_alchemiser.services.enhanced.market_data_service import MarketDataService
 from the_alchemiser.services.enhanced.order_service import OrderService
 from the_alchemiser.services.enhanced.position_service import PositionService
+from the_alchemiser.utils.num import floats_equal
 
 
 class TradingServiceManager:
@@ -130,7 +131,8 @@ class TradingServiceManager:
     def close_position(self, symbol: str, percentage: float = 100.0) -> dict[str, Any]:
         """Close a position using liquidation"""
         try:
-            if percentage != 100.0:
+            # Sonar: replace float equality check with tolerance
+            if not floats_equal(percentage, 100.0):
                 return {
                     "success": False,
                     "error": "Partial position closure not directly supported. Use liquidate_position for full closure.",

--- a/the_alchemiser/utils/num.py
+++ b/the_alchemiser/utils/num.py
@@ -1,0 +1,17 @@
+from math import isclose
+from typing import Any
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - numpy optional
+    np = None  # type: ignore[assignment]
+
+
+def floats_equal(a: Any, b: Any, rel_tol: float = 1e-9, abs_tol: float = 1e-12) -> bool:
+    """Compare two floats or arrays with tolerance."""
+    try:
+        if np is not None and (isinstance(a, np.ndarray) or isinstance(b, np.ndarray)):
+            return bool(np.isclose(a, b, rtol=rel_tol, atol=abs_tol, equal_nan=False).all())
+    except Exception:  # pragma: no cover - fall back to scalar comparison
+        pass
+    return isclose(float(a), float(b), rel_tol=rel_tol, abs_tol=abs_tol)


### PR DESCRIPTION
## Summary
- replace fragile float equality check with tolerant `floats_equal` utility
- drop tautological branches in `phase3_summary` and CLI dashboard utilities
- consolidate Alpaca client error handling and simplify trading engine order display

## Testing
- `ruff check scripts/phase3_summary.py the_alchemiser/application/alpaca_client.py the_alchemiser/application/trading_engine.py the_alchemiser/interface/cli/dashboard_utils.py the_alchemiser/services/enhanced/trading_service_manager.py the_alchemiser/utils/num.py tests/application/test_alpaca_client.py tests/application/test_trading_engine.py tests/interface/cli/test_dashboard_utils.py tests/scripts/test_phase3_summary.py tests/services/enhanced/test_trading_service_manager.py tests/utils/test_num.py`
- `mypy scripts/phase3_summary.py the_alchemiser/application/alpaca_client.py the_alchemiser/application/trading_engine.py the_alchemiser/interface/cli/dashboard_utils.py the_alchemiser/services/enhanced/trading_service_manager.py the_alchemiser/utils/num.py tests/application/test_alpaca_client.py tests/application/test_trading_engine.py tests/interface/cli/test_dashboard_utils.py tests/scripts/test_phase3_summary.py tests/services/enhanced/test_trading_service_manager.py tests/utils/test_num.py`
- `pytest tests/application/test_alpaca_client.py tests/services/enhanced/test_trading_service_manager.py tests/scripts/test_phase3_summary.py tests/interface/cli/test_dashboard_utils.py tests/application/test_trading_engine.py tests/utils/test_num.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689749f6d2088333a25fd972ddb5b219