### PR TITLE
Add coverage tooling and CLI tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+source = the_alchemiser
+omit =
+    */.venv/*
+    */tests/*
+    */migrations/*
+    */version.py
+concurrency = multiprocessing,thread
+
+[report]
+skip_covered = False

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: tests
+on: [push, pull_request]
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      DRY_RUN: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -U pip
+      - run: pip install -e .
+      - run: pip install pytest pytest-cov pytest-timeout
+      - run: |
+          pytest -q --cov=the_alchemiser --cov-branch \
+            --cov-report=term-missing --cov-report=xml --cov-report=html \
+            --cov-fail-under=85
+      - uses: actions/upload-artifact@v4
+        with:
+          name: htmlcov
+          path: htmlcov

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,64 @@
+# Coverage Plan for The Alchemiser CLI
+
+## Mode to Module Map
+
+### `alchemiser signal`
+- Entry: `the_alchemiser.interface.cli.cli:signal`
+- Core logic: `the_alchemiser.main.run_all_signals_display`
+- Key modules involved:
+  - `the_alchemiser.main` (signal orchestration)
+  - `the_alchemiser.application.strategy_manager`
+  - `the_alchemiser.services` signal generators (Nuclear, TECL, KLM)
+  - `the_alchemiser.interface.cli.cli_formatter` (Rich output)
+
+### `alchemiser trade` (paper)
+- Entry: `the_alchemiser.interface.cli.cli:trade`
+- Core logic: `the_alchemiser.main.run_multi_strategy_trading`
+- Key modules involved:
+  - `the_alchemiser.execution.trading_engine`
+  - `the_alchemiser.application.strategy_manager`
+  - `the_alchemiser.services` order sizing & risk controls
+  - `the_alchemiser.infrastructure.logging` utilities
+
+### `alchemiser trade --live`
+- Entry: same `trade` command with `--live` flag
+- Exercises live‑trading branches in `run_multi_strategy_trading`
+- Additional modules:
+  - `the_alchemiser.execution.trading_engine` live path
+  - Broker adapters (`the_alchemiser.infrastructure.broker.*`)
+  - Enhanced risk checks and confirmation prompts
+
+## Reproducible Coverage Commands
+
+```bash
+# Clean prior data
+find . -name '.coverage*' -delete
+
+# Unit + integration coverage
+pytest -q \
+  --cov=the_alchemiser --cov-branch \
+  --cov-report=term-missing --cov-report=xml --cov-report=html
+
+# CLI-driven coverage (simulate each mode)
+export DRY_RUN=1 PYTHONHASHSEED=0
+coverage run -m the_alchemiser.interface.cli.cli signal --no-header || true
+coverage run -a -m the_alchemiser.interface.cli.cli trade --force --ignore-market-hours || true
+coverage run -a -m the_alchemiser.interface.cli.cli trade --live --force --ignore-market-hours || true
+
+# Combine + report
+coverage combine
+coverage html
+coverage xml
+coverage report -m
+```
+
+## Targeted Test Recommendations
+- Mock broker/network/time side effects to ensure dry runs.
+- Exercise error paths: API timeouts, rejected orders, rate limits.
+- Edge cases: zero or conflicting signals, stale cache, missing credentials.
+- Risk controls: position limits, notional caps, duplicate-order guards.
+- CLI UX: invalid flags, help text, version, dry-run behaviour.
+
+## CI Integration
+A GitHub Actions workflow (`.github/workflows/tests.yml`) runs tests with branch coverage,
+exports `DRY_RUN=1`, uploads `htmlcov` artefacts and enforces `--cov-fail-under=85`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,9 @@ addopts = [
     "--cov=the_alchemiser",        # Coverage for main package
     "--cov-report=term-missing",   # Show missing lines in coverage
     "--cov-report=html:htmlcov",   # HTML coverage report
+    "--cov-report=xml",            # XML coverage report for CI
     "--cov-branch",                # Include branch coverage
+    "--cov-fail-under=85",         # Enforce minimum coverage threshold
     "--timeout=30",                # Global test timeout
 ]
 

--- a/tests/interface/cli/test_cli_commands.py
+++ b/tests/interface/cli/test_cli_commands.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from the_alchemiser.interface.cli.cli import app
+
+runner = CliRunner()
+
+
+@patch("the_alchemiser.main.run_all_signals_display", return_value=True)
+def test_signal_command(mock_run) -> None:
+    result = runner.invoke(app, ["signal", "--no-header"], env={"DRY_RUN": "1"})
+    assert result.exit_code == 0
+    mock_run.assert_called_once()
+
+
+@patch("the_alchemiser.main.run_multi_strategy_trading", return_value=True)
+def test_trade_paper_command(mock_run) -> None:
+    result = runner.invoke(
+        app,
+        ["trade", "--no-header", "--force", "--ignore-market-hours"],
+        env={"DRY_RUN": "1"},
+    )
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(live_trading=False, ignore_market_hours=True)
+
+
+@patch("the_alchemiser.main.run_multi_strategy_trading", return_value=True)
+def test_trade_live_command(mock_run) -> None:
+    result = runner.invoke(
+        app,
+        ["trade", "--live", "--force", "--no-header", "--ignore-market-hours"],
+        env={"DRY_RUN": "1"},
+    )
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(live_trading=True, ignore_market_hours=True)


### PR DESCRIPTION
## Summary
- add coverage configuration with branch tracking
- document coverage plan and commands
- test CLI modes via Typer runner
- set up CI workflow running pytest with coverage
- install pytest, pytest-cov, and pytest-timeout before executing tests in CI

## Testing
- `poetry run pre-commit run --files .github/workflows/tests.yml` *(skipped: no files to check)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_68986650bf5c8333a4753fa6209a2710