### PR TITLE
refactor: simplify default fallbacks

### DIFF
--- a/the_alchemiser/interface/email/templates/base.py
+++ b/the_alchemiser/interface/email/templates/base.py
@@ -52,8 +52,7 @@ class BaseEmailTemplate:
         timestamp: datetime | None = None,
     ) -> str:
         """Get combined header and status in one section."""
-        if timestamp is None:
-            timestamp = datetime.now()
+        timestamp = timestamp or datetime.now()
 
         return f"""
         <tr>
@@ -86,8 +85,7 @@ class BaseEmailTemplate:
         timestamp: datetime | None = None,
     ) -> str:
         """Get HTML status banner section."""
-        if timestamp is None:
-            timestamp = datetime.now()
+        timestamp = timestamp or datetime.now()
 
         return f"""
         <tr>

--- a/the_alchemiser/services/error_recovery.py
+++ b/the_alchemiser/services/error_recovery.py
@@ -115,9 +115,7 @@ class TradingErrorRecovery(ErrorRecoveryStrategy):
 
     def _handle_rate_limit(self, error: EnhancedAlchemiserError) -> RecoveryResult:
         """Handle rate limit errors with appropriate delays."""
-        retry_delay = getattr(error, "retry_after", 60.0)
-        if retry_delay is None:
-            retry_delay = 60.0
+        retry_delay = getattr(error, "retry_after", None) or 60.0
 
         return RecoveryResult(
             success=True,


### PR DESCRIPTION
## Summary
- streamline rate limit delay handling
- simplify timestamp defaulting in email templates

## Testing
- `ruff check the_alchemiser/services/error_recovery.py the_alchemiser/interface/email/templates/base.py`
- `black the_alchemiser/services/error_recovery.py the_alchemiser/interface/email/templates/base.py`
- `pytest` *(fails: AttributeError: module 'the_alchemiser' has no attribute 'core')*
- `pytest tests/integration/test_service_integration.py::TestServiceIntegration::test_cached_market_data_flow -q` *(fails: AttributeError: module 'the_alchemiser' has no attribute 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6898e6598598833386490cae2298b397