### PR TITLE
Add unit tests for utility helpers

### DIFF
--- a/tests/unit/test_account_utils.py
+++ b/tests/unit/test_account_utils.py
@@ -1,0 +1,33 @@
+"""Unit tests for account utility helpers."""
+
+import importlib.util
+from pathlib import Path
+
+# Load module directly to avoid importing heavy services package
+spec = importlib.util.spec_from_file_location(
+    "account_utils", Path(__file__).resolve().parents[2] / "the_alchemiser/services/account_utils.py"
+)
+account_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(account_utils)  # type: ignore[attr-defined]
+extract_current_position_values = account_utils.extract_current_position_values
+
+
+def test_extract_current_position_values_basic():
+    """It converts market value strings to floats."""
+    positions = {
+        "AAPL": {"market_value": "1000.50"},
+        "MSFT": {"market_value": 2000},
+    }
+    result = extract_current_position_values(positions)
+    assert result == {"AAPL": 1000.50, "MSFT": 2000.0}
+
+
+def test_extract_current_position_values_handles_invalid():
+    """It defaults to zero for missing or invalid values."""
+    positions = {
+        "TSLA": {"market_value": "invalid"},
+        "GOOG": {},
+    }
+    result = extract_current_position_values(positions)
+    assert result["TSLA"] == 0.0
+    assert result["GOOG"] == 0.0

--- a/tests/unit/test_trading_engine_utils.py
+++ b/tests/unit/test_trading_engine_utils.py
@@ -1,0 +1,18 @@
+"""Tests for lightweight utilities in trading engine."""
+
+import pytest
+
+trading_engine = pytest.importorskip("the_alchemiser.application.trading_engine")
+_create_default_account_info = trading_engine._create_default_account_info
+
+
+def test_create_default_account_info_defaults():
+    info = _create_default_account_info()
+    assert info["account_id"] == "unknown"
+    assert info["equity"] == 0.0
+    assert info["status"] == "INACTIVE"
+
+
+def test_create_default_account_info_custom_id():
+    info = _create_default_account_info("abc123")
+    assert info["account_id"] == "abc123"

--- a/tests/unit/test_trading_math.py
+++ b/tests/unit/test_trading_math.py
@@ -8,6 +8,8 @@ to ensure accuracy and handle edge cases.
 import math
 from decimal import ROUND_HALF_UP, Decimal, getcontext
 
+import pytest
+
 from tests.conftest import ABS_TOL, REL_TOL
 
 # Set high precision for Decimal calculations
@@ -372,3 +374,21 @@ class TestHelperFunctions:
             Decimal("1000"), Decimal("333.33"), round_down=True
         )
         assert shares_rounded == Decimal("3")
+
+
+class TestAllocationDiscrepancy:
+    """Tests for calculate_allocation_discrepancy."""
+
+    def test_allocation_discrepancy_standard_case(self):
+        from the_alchemiser.domain.math.trading_math import calculate_allocation_discrepancy
+
+        current_weight, diff = calculate_allocation_discrepancy(0.25, 3000, 10000)
+        assert current_weight == pytest.approx(0.3)
+        assert diff == pytest.approx(-0.05)
+
+    def test_allocation_discrepancy_handles_invalid_inputs(self):
+        from the_alchemiser.domain.math.trading_math import calculate_allocation_discrepancy
+
+        current_weight, diff = calculate_allocation_discrepancy(0.25, "bad", 0)
+        assert current_weight == 0.0
+        assert diff == pytest.approx(0.25)


### PR DESCRIPTION
## Summary
- add tests for account utility value extraction
- cover trading engine default account info helper
- test allocation discrepancy math with tolerance

## Testing
- `pre-commit run --files tests/unit/test_account_utils.py tests/unit/test_trading_engine_utils.py tests/unit/test_trading_math.py`
- `pytest tests/unit/test_account_utils.py tests/unit/test_trading_engine_utils.py tests/unit/test_trading_math.py::TestAllocationDiscrepancy -q`

------
https://chatgpt.com/codex/tasks/task_e_689ba2939f3c833394fd4c0fabd46535