### PR TITLE
docs: standardize docstrings to Google format

### DIFF
--- a/the_alchemiser/interface/cli/cli.py
+++ b/the_alchemiser/interface/cli/cli.py
@@ -36,7 +36,13 @@ console = Console()
 
 
 def show_welcome() -> None:
-    """Display a beautiful welcome message"""
+    """Render the CLI welcome banner.
+
+    Displays a rich-formatted header panel describing the trading system.
+
+    Returns:
+        None
+    """
     welcome_text = Text()
     welcome_text.append(" The Alchemiser Quantitative Trading System\n", style="bold cyan")
     welcome_text.append("Advanced Multi-Strategy Trading System", style="italic")

--- a/the_alchemiser/interface/cli/cli_formatter.py
+++ b/the_alchemiser/interface/cli/cli_formatter.py
@@ -18,9 +18,14 @@ def render_technical_indicators(
     strategy_signals: dict[Any, Any],
     console: Console | None = None,  # TODO: Phase 13 - CLISignalData
 ) -> None:
-    """
-    Pretty-print technical indicators using rich Table.
-    If console is None, creates a new Console and prints directly.
+    """Render technical indicators as a Rich table.
+
+    Args:
+        strategy_signals: Mapping of strategy identifiers to indicator data.
+        console: Optional console used for rendering. Creates a new console if ``None``.
+
+    Returns:
+        None
     """
     all_indicators: dict[str, dict[str, Any]] = {}
     for _, data in strategy_signals.items():
@@ -122,7 +127,15 @@ def render_strategy_signals(
     strategy_signals: dict[Any, Any],
     console: Console | None = None,  # TODO: Phase 13 - CLISignalData
 ) -> None:
-    """Pretty-print strategy signals using rich panels with detailed explanations."""
+    """Render strategy signals using Rich panels.
+
+    Args:
+        strategy_signals: Mapping of strategy identifiers to their signal data.
+        console: Optional console used for rendering. A new console is created if ``None``.
+
+    Returns:
+        None
+    """
     c = console or Console()
 
     if not strategy_signals:

--- a/the_alchemiser/utils/num.py
+++ b/the_alchemiser/utils/num.py
@@ -8,10 +8,24 @@ except ImportError:  # pragma: no cover - numpy optional
 
 
 def floats_equal(a: Any, b: Any, rel_tol: float = 1e-9, abs_tol: float = 1e-12) -> bool:
-    """Compare two floats or arrays with tolerance."""
+    """Check whether two floating-point values are approximately equal.
+
+    Args:
+        a: First value or array to compare.
+        b: Second value or array to compare.
+        rel_tol: Relative tolerance for comparison.
+        abs_tol: Absolute tolerance for comparison.
+
+    Returns:
+        bool: True if the values are equal within the given tolerances; otherwise False.
+    """
     try:
         if np is not None and (isinstance(a, np.ndarray) or isinstance(b, np.ndarray)):
             return bool(np.isclose(a, b, rtol=rel_tol, atol=abs_tol, equal_nan=False).all())
-    except (TypeError, ValueError, AttributeError):  # pragma: no cover - fall back to scalar comparison
+    except (
+        TypeError,
+        ValueError,
+        AttributeError,
+    ):  # pragma: no cover - fall back to scalar comparison
         pass
     return isclose(float(a), float(b), rel_tol=rel_tol, abs_tol=abs_tol)


### PR DESCRIPTION
## Summary
- clean up CLI welcome banner docstring
- clarify numerical comparison helper docstring
- document CLI formatting helpers

## Testing
- `make format`
- `make lint` *(fails: UP045 Use `X | None` for type annotations)*
- `ruff check the_alchemiser/utils/num.py the_alchemiser/interface/cli/cli.py the_alchemiser/interface/cli/cli_formatter.py`
- `make test` *(fails: several symbol classifier tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_689cc66707b483339aaafaed1a671158