### PR TITLE
chore: avoid float equality in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for importing shared utilities."""

--- a/tests/_tolerances.py
+++ b/tests/_tolerances.py
@@ -1,0 +1,4 @@
+"""Shared numeric tolerances for tests."""
+
+DEFAULT_RTL = 1e-7
+DEFAULT_ATL = 1e-12

--- a/tests/unit/application/mapping/test_strategy_signal_mapping.py
+++ b/tests/unit/application/mapping/test_strategy_signal_mapping.py
@@ -1,3 +1,6 @@
+import pytest
+
+from tests._tolerances import DEFAULT_ATL
 from the_alchemiser.application.mapping.strategy_signal_mapping import (
     legacy_signal_to_typed,
 )
@@ -15,9 +18,11 @@ def test_legacy_to_typed_basic_buy():
 
     assert typed["symbol"] == "AAPL"
     assert typed["action"] == "BUY"
-    assert typed["confidence"] == 0.75
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert typed["confidence"] == pytest.approx(0.75, rel=1e-9, abs=DEFAULT_ATL)
     assert typed["reasoning"] == "RSI oversold"
-    assert typed["allocation_percentage"] == 25.0
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert typed["allocation_percentage"] == pytest.approx(25.0, rel=1e-9, abs=DEFAULT_ATL)
 
 
 def test_legacy_to_typed_action_enum_like():

--- a/tests/unit/services/trading/test_get_account_summary_enriched_flag.py
+++ b/tests/unit/services/trading/test_get_account_summary_enriched_flag.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from tests._tolerances import DEFAULT_ATL
+
 from the_alchemiser.services.trading.trading_service_manager import TradingServiceManager
 
 
@@ -46,7 +48,8 @@ def test_account_summary_enriched_legacy(monkeypatch: pytest.MonkeyPatch):
     out = mgr.get_account_summary_enriched()
     # Without flag, returns legacy dict directly
     assert isinstance(out, dict)
-    assert out["equity"] == 100000.0
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert out["equity"] == pytest.approx(100000.0, rel=1e-9, abs=DEFAULT_ATL)
     assert "summary" not in out
 
 
@@ -57,6 +60,11 @@ def test_account_summary_enriched_typed(monkeypatch: pytest.MonkeyPatch):
     assert isinstance(out, dict)
     assert "raw" in out and "summary" in out
     summary = out["summary"]
-    assert summary["equity"] == 100000.0
-    assert summary["cash"] == 25000.0
-    assert summary["calculated_metrics"]["cash_ratio"] == 0.25
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert summary["equity"] == pytest.approx(100000.0, rel=1e-9, abs=DEFAULT_ATL)
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert summary["cash"] == pytest.approx(25000.0, rel=1e-9, abs=DEFAULT_ATL)
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert summary["calculated_metrics"]["cash_ratio"] == pytest.approx(
+        0.25, rel=1e-9, abs=DEFAULT_ATL
+    )

--- a/tests/unit/services/trading/test_get_positions_enriched_flag.py
+++ b/tests/unit/services/trading/test_get_positions_enriched_flag.py
@@ -1,3 +1,6 @@
+import pytest
+
+from tests._tolerances import DEFAULT_ATL
 from the_alchemiser.services.trading.trading_service_manager import TradingServiceManager
 
 
@@ -56,5 +59,7 @@ def test_get_positions_enriched_typed(monkeypatch):
     assert "raw" in first and "summary" in first
     summary = first["summary"]
     assert summary["symbol"] == "AAPL"
-    assert summary["qty"] == 10.0
-    assert summary["avg_entry_price"] == 150.0
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert summary["qty"] == pytest.approx(10.0, rel=1e-9, abs=DEFAULT_ATL)
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert summary["avg_entry_price"] == pytest.approx(150.0, rel=1e-9, abs=DEFAULT_ATL)

--- a/tests/unit/services/trading/test_place_limit_order_flag.py
+++ b/tests/unit/services/trading/test_place_limit_order_flag.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from tests._tolerances import DEFAULT_ATL
+
 from the_alchemiser.services.trading.trading_service_manager import TradingServiceManager
 
 
@@ -111,7 +113,8 @@ def test_place_limit_order_typed(monkeypatch: pytest.MonkeyPatch):
         assert "order" in out
         summary = out["order"]["summary"]
         assert summary["symbol"] == "MSFT"
-        assert summary["qty"] == 10.0
+        # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+        assert summary["qty"] == pytest.approx(10.0, rel=1e-9, abs=DEFAULT_ATL)
         assert summary["type"].lower() == "limit"
     finally:
         builtins.__import__ = real_import  # type: ignore[assignment]

--- a/tests/unit/services/trading/test_place_market_order_flag.py
+++ b/tests/unit/services/trading/test_place_market_order_flag.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from tests._tolerances import DEFAULT_ATL
 from the_alchemiser.services.trading.trading_service_manager import TradingServiceManager
 
 
@@ -97,6 +98,9 @@ def test_place_market_order_typed(monkeypatch: pytest.MonkeyPatch):
         assert out["success"] is True
         assert "order" in out
         assert out["order"]["summary"]["symbol"] == "MSFT"
-        assert out["order"]["summary"]["qty"] == 10.0
+        # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+        assert out["order"]["summary"]["qty"] == pytest.approx(
+            10.0, rel=1e-9, abs=DEFAULT_ATL
+        )
     finally:
         builtins.__import__ = real_import  # type: ignore[assignment]

--- a/tests/unit/services/trading/test_portfolio_value_flag.py
+++ b/tests/unit/services/trading/test_portfolio_value_flag.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 
 import pytest
 
+from tests._tolerances import DEFAULT_ATL
+
 from the_alchemiser.services.trading.trading_service_manager import TradingServiceManager
 
 
@@ -34,7 +36,8 @@ def test_get_portfolio_value_legacy(monkeypatch: pytest.MonkeyPatch):
     mgr = make_manager(12345.67)
     result = mgr.get_portfolio_value()
     assert isinstance(result, float)
-    assert result == 12345.67
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert result == pytest.approx(12345.67, rel=1e-9, abs=DEFAULT_ATL)
 
 
 def test_get_portfolio_value_typed(monkeypatch: pytest.MonkeyPatch):
@@ -42,7 +45,8 @@ def test_get_portfolio_value_typed(monkeypatch: pytest.MonkeyPatch):
     mgr = make_manager(12345.67)
     result = mgr.get_portfolio_value()
     assert isinstance(result, dict)
-    assert result["value"] == 12345.67
+    # Sonar rule: avoid direct float comparison (IEEE-754 rounding).
+    assert result["value"] == pytest.approx(12345.67, rel=1e-9, abs=DEFAULT_ATL)
     money = result["money"]
     assert money is not None
     assert money.currency == "USD"


### PR DESCRIPTION
## Summary
- add shared tolerance constants for tests
- use `pytest.approx` for float comparisons to satisfy SonarQube rule
- ensure tests package can import helpers

## Testing
- `pytest tests/unit/application/mapping/test_strategy_signal_mapping.py tests/unit/services/trading/test_get_account_summary_enriched_flag.py tests/unit/services/trading/test_get_positions_enriched_flag.py tests/unit/services/trading/test_place_limit_order_flag.py tests/unit/services/trading/test_place_market_order_flag.py tests/unit/services/trading/test_portfolio_value_flag.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a06a96925483339797d0899eda7495