### PR TITLE
docs: remove direnv setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,7 @@ Internal notes on how the trading bot is put together and how the pieces interac
 
 ## Quick Start
 
-### Environment Setup with direnv (Recommended)
-
-1. **Install direnv**: `brew install direnv` (macOS) or see [direnv.net](https://direnv.net/)
-2. **Configure your shell**: Add `eval "$(direnv hook zsh)"` to `~/.zshrc` (or bash equivalent)
-3. **Set up the project**: `cp .envrc.template .envrc && direnv allow`
-4. **Test**: `cd .. && cd the-alchemiser` - you should see "🔧 Environment activated"
-
-Now your Python virtual environment and all project settings are automatically activated when you enter the directory!
-
-### Manual Setup (Alternative)
-
-If you prefer manual environment management:
+### Environment Setup
 
 ```bash
 source .venv/bin/activate


### PR DESCRIPTION
## Summary
- remove direnv instructions from README
- simplify environment setup description

## Testing
- `pre-commit run --files README.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'the_alchemiser')*


------
https://chatgpt.com/codex/tasks/task_e_68a075d9d8dc8333834bca4166507ae5