### PR TITLE
refactor: switch to data provider facade

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code ownership for critical modules
+/the_alchemiser/infrastructure/data_providers/unified_data_provider_facade.py @alchemiser-devs

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,19 @@ status:
 
 # Development
 test:
-	@echo "🧪 Running tests..."
-	poetry run pytest tests/ -v
+        @echo "🧪 Running tests..."
+        poetry run pytest tests/ -v
+
+contract-tests:
+        @echo "🤝 Running contract tests..."
+        poetry run pytest tests/contracts -m contract -v
+
+check-no-legacy-dataprovider:
+        @bash tools/ci/check_no_legacy_dataprovider.sh
+
+smoke:
+        @echo "🚬 Running CLI smoke tests..."
+        poetry run pytest tests/e2e/test_cli_trade.py -v
 
 format:
 	@echo "🎨 Formatting code..."

--- a/README.md
+++ b/README.md
@@ -463,7 +463,14 @@ class TradingEngine:
 
 ### Data Provider Architecture
 
-**Unified Data Access** (`core/data/data_provider.py`):
+#### Data Provider Facade
+
+All services now import `UnifiedDataProvider` from
+`the_alchemiser.infrastructure.data_providers.unified_data_provider_facade`.
+The facade preserves the legacy interface while delegating to modular
+services. The old `data_provider.py` module is deprecated.
+
+**Unified Data Access**:
 
 - **Real-time Priority**: WebSocket data preferred over REST
 - **Automatic Fallbacks**: REST API backup for real-time failures

--- a/docs/adr/001-data-provider-facade.md
+++ b/docs/adr/001-data-provider-facade.md
@@ -1,0 +1,18 @@
+# ADR 001: Data Provider Facade
+
+## Context
+Legacy `data_provider.py` coupled market data and trading logic. A facade
+now wraps the modular services so existing callers can migrate without
+behaviour changes.
+
+## Decision
+All code must import `UnifiedDataProvider` from
+`infrastructure/data_providers/unified_data_provider_facade`. The legacy
+module emits a `DeprecationWarning` and will raise `ImportError` once
+`IMPORTERROR_ON_LEGACY=1` is set in CI.
+
+## Consequences
+- Centralised data access via facade.
+- Guard rails prevent reintroducing the old module.
+- After two to four weeks of green builds the legacy module will be
+removed.

--- a/docs/data-provider-facade.md
+++ b/docs/data-provider-facade.md
@@ -1,0 +1,15 @@
+# Data Provider Facade
+
+All access to market data and account information must go through the
+`UnifiedDataProvider` facade located at
+`the_alchemiser.infrastructure.data_providers.unified_data_provider_facade`.
+
+The legacy `data_provider.py` module is deprecated and kept only for
+parity tests during migration. Importing it will emit a
+`DeprecationWarning` and eventually raise `ImportError`.
+
+## Rationale
+
+The facade preserves the original interface while delegating to modular
+services. This enables a clean transition without behaviour drift and
+provides a single integration point for future enhancements.

--- a/docs/deprecation_timeline.md
+++ b/docs/deprecation_timeline.md
@@ -1,0 +1,5 @@
+# Deprecation Timeline
+
+- 2025-01-01: flip `IMPORTERROR_ON_LEGACY` in CI and remove
+  `the_alchemiser/infrastructure/data_providers/data_provider.py` after
+  two to four weeks of green builds.

--- a/tests/contracts/test_data_provider_parity.py
+++ b/tests/contracts/test_data_provider_parity.py
@@ -1,0 +1,141 @@
+from datetime import datetime, UTC
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from the_alchemiser.infrastructure.data_providers.data_provider import UnifiedDataProvider as LegacyProvider
+from the_alchemiser.infrastructure.data_providers.unified_data_provider_facade import UnifiedDataProvider as FacadeProvider
+from the_alchemiser.services.errors.exceptions import MarketDataError
+
+pytestmark = pytest.mark.contract
+
+GOLDEN_DF = pd.DataFrame(
+    {
+        "Open": [1.0, 2.0],
+        "High": [1.2, 2.2],
+        "Low": [0.8, 1.8],
+        "Close": [1.1, 2.1],
+        "Volume": [100, 200],
+    },
+    index=pd.to_datetime([
+        datetime(2023, 1, 1, tzinfo=UTC),
+        datetime(2023, 1, 2, tzinfo=UTC),
+    ]),
+)
+GOLDEN_DF.index.name = "Date"
+
+
+@pytest.fixture(params=[LegacyProvider, FacadeProvider])
+def provider(request, monkeypatch):
+    cls = request.param
+    if cls is LegacyProvider:
+        monkeypatch.setattr(
+            "the_alchemiser.infrastructure.secrets.secrets_manager.SecretsManager.get_alpaca_keys",
+            lambda self, paper_trading=True: ("key", "secret"),
+        )
+        prov = cls(paper_trading=True, enable_real_time=False)
+
+        def fake_bars(request_obj):
+            bar1 = SimpleNamespace(
+                open=1.0,
+                high=1.2,
+                low=0.8,
+                close=1.1,
+                volume=100,
+                timestamp=datetime(2023, 1, 1, tzinfo=UTC),
+            )
+            bar2 = SimpleNamespace(
+                open=2.0,
+                high=2.2,
+                low=1.8,
+                close=2.1,
+                volume=200,
+                timestamp=datetime(2023, 1, 2, tzinfo=UTC),
+            )
+            return SimpleNamespace(AAPL=[bar1, bar2])
+
+        monkeypatch.setattr(prov.data_client, "get_stock_bars", fake_bars)
+        monkeypatch.setattr(
+            prov.data_client,
+            "get_stock_latest_quote",
+            lambda req: {"AAPL": SimpleNamespace(bid_price=10.0, ask_price=10.2)},
+        )
+        monkeypatch.setattr(
+            prov.trading_client,
+            "get_account",
+            lambda: SimpleNamespace(model_dump=lambda: {"equity": 1000}),
+        )
+        monkeypatch.setattr(
+            prov.trading_client,
+            "get_all_positions",
+            lambda: [SimpleNamespace(model_dump=lambda: {"symbol": "AAPL", "qty": "10"})],
+        )
+    else:
+        monkeypatch.setattr(
+            "the_alchemiser.services.shared.secrets_service.SecretsService.get_alpaca_credentials",
+            lambda self, paper_trading=True: ("key", "secret"),
+        )
+        prov = cls(paper_trading=True, enable_real_time=False)
+        monkeypatch.setattr(
+            prov._market_data_client,
+            "get_historical_bars",
+            lambda symbol, period, timeframe: GOLDEN_DF,
+        )
+        monkeypatch.setattr(
+            prov._market_data_client,
+            "get_latest_quote",
+            lambda symbol: (10.0, 10.2),
+        )
+        monkeypatch.setattr(
+            prov._account_service,
+            "get_account_info",
+            lambda: SimpleNamespace(to_dict=lambda: {"equity": 1000}),
+        )
+        monkeypatch.setattr(
+            prov._account_service,
+            "get_positions_dict",
+            lambda: {"AAPL": {"symbol": "AAPL", "qty": "10"}},
+        )
+    return prov
+
+
+def test_get_data_parity(provider):
+    df = provider.get_data("AAPL", period="1d", interval="1d")
+    pd.testing.assert_frame_equal(df, GOLDEN_DF)
+
+
+def test_get_current_price_parity(provider):
+    price = provider.get_current_price("AAPL")
+    assert price == pytest.approx(10.1)
+
+
+def test_get_latest_quote_parity(provider):
+    bid, ask = provider.get_latest_quote("AAPL")
+    assert bid == 10.0
+    assert ask == 10.2
+
+
+def test_account_positions_parity(provider):
+    info = provider.get_account_info()
+    assert info == {"equity": 1000}
+    positions = provider.get_positions()
+    assert positions == [{"symbol": "AAPL", "qty": "10"}]
+
+
+def test_error_parity(provider, monkeypatch):
+    if isinstance(provider, LegacyProvider):
+        monkeypatch.setattr(
+            provider.data_client,
+            "get_stock_bars",
+            lambda req: (_ for _ in ()).throw(MarketDataError("boom")),
+        )
+    else:
+        monkeypatch.setattr(
+            provider._market_data_client,
+            "get_historical_bars",
+            lambda symbol, period, timeframe: (_ for _ in ()).throw(MarketDataError("boom")),
+        )
+    df = provider.get_data("AAPL", period="1d", interval="1d")
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty

--- a/tests/e2e/test_cli_trade.py
+++ b/tests/e2e/test_cli_trade.py
@@ -1,0 +1,42 @@
+from typing import List
+
+import pytest
+from typer.testing import CliRunner
+
+from the_alchemiser.interface.cli.cli import app
+from the_alchemiser.infrastructure.data_providers.unified_data_provider_facade import (
+    UnifiedDataProviderFacade,
+)
+
+
+def _stub_main(calls: List[UnifiedDataProviderFacade]):
+    def _inner(argv=None):
+        from the_alchemiser.container.application_container import ApplicationContainer
+        from the_alchemiser.services.shared.secrets_service import SecretsService
+
+        # Avoid real credential lookup
+        SecretsService.get_alpaca_credentials = lambda self, paper_trading: ("key", "secret")
+        container = ApplicationContainer()
+        dp = container.infrastructure.data_provider()
+        calls.append(dp)
+        return True
+
+    return _inner
+
+
+def test_trade_paper_uses_facade(monkeypatch):
+    calls: List[UnifiedDataProviderFacade] = []
+    monkeypatch.setattr("the_alchemiser.main.main", _stub_main(calls))
+    runner = CliRunner()
+    result = runner.invoke(app, ["trade"])
+    assert result.exit_code == 0
+    assert isinstance(calls[0], UnifiedDataProviderFacade)
+
+
+def test_trade_live_dry_run(monkeypatch):
+    calls: List[UnifiedDataProviderFacade] = []
+    monkeypatch.setattr("the_alchemiser.main.main", _stub_main(calls))
+    runner = CliRunner()
+    result = runner.invoke(app, ["trade", "--live"])
+    assert result.exit_code == 0
+    assert isinstance(calls[0], UnifiedDataProviderFacade)

--- a/the_alchemiser/application/trading/engine_service.py
+++ b/the_alchemiser/application/trading/engine_service.py
@@ -317,7 +317,7 @@ class TradingEngine:
 
         # Initialize data provider (existing logic)
         try:
-            from the_alchemiser.infrastructure.data_providers.data_provider import (
+            from the_alchemiser.infrastructure.data_providers.unified_data_provider_facade import (
                 UnifiedDataProvider,
             )
 

--- a/the_alchemiser/container/infrastructure_providers.py
+++ b/the_alchemiser/container/infrastructure_providers.py
@@ -2,7 +2,10 @@
 
 from dependency_injector import containers, providers
 
-from the_alchemiser.infrastructure.data_providers.data_provider import UnifiedDataProvider
+# Use the facade implementation for all data provider access
+from the_alchemiser.infrastructure.data_providers.unified_data_provider_facade import (
+    UnifiedDataProvider,
+)
 from the_alchemiser.services.repository.alpaca_manager import AlpacaManager
 
 

--- a/the_alchemiser/domain/strategies/klm_ensemble_engine.py
+++ b/the_alchemiser/domain/strategies/klm_ensemble_engine.py
@@ -441,7 +441,7 @@ def main() -> None:
 
     try:
         # Initialize ensemble
-        from the_alchemiser.infrastructure.data_providers.data_provider import UnifiedDataProvider
+        from the_alchemiser.infrastructure.data_providers.unified_data_provider_facade import UnifiedDataProvider
 
         data_provider = UnifiedDataProvider(paper_trading=True)
         ensemble = KLMStrategyEnsemble(data_provider=data_provider)

--- a/the_alchemiser/domain/strategies/klm_trading_bot.py
+++ b/the_alchemiser/domain/strategies/klm_trading_bot.py
@@ -29,7 +29,7 @@ from the_alchemiser.domain.strategies.klm_ensemble_engine import KLMStrategyEnse
 
 # Local imports
 from the_alchemiser.infrastructure.alerts.alert_service import Alert
-from the_alchemiser.infrastructure.data_providers.data_provider import UnifiedDataProvider
+from the_alchemiser.infrastructure.data_providers.unified_data_provider_facade import UnifiedDataProvider
 
 warnings.filterwarnings("ignore")
 

--- a/the_alchemiser/domain/strategies/strategy_manager.py
+++ b/the_alchemiser/domain/strategies/strategy_manager.py
@@ -122,7 +122,7 @@ class MultiStrategyManager:
 
         # Use provided shared_data_provider, or create one if not given
         if shared_data_provider is None:
-            from the_alchemiser.infrastructure.data_providers.data_provider import (
+            from the_alchemiser.infrastructure.data_providers.unified_data_provider_facade import (
                 UnifiedDataProvider,
             )
 

--- a/the_alchemiser/infrastructure/data_providers/data_provider.py
+++ b/the_alchemiser/infrastructure/data_providers/data_provider.py
@@ -1,4 +1,12 @@
-"""Unified historical and real-time market data access layer."""
+"""Unified historical and real-time market data access layer.
+
+This legacy module is retained temporarily for parity tests.
+Do not edit. All new code must import the facade implementation.
+TODO: flip ImportError and delete after 2025-01-01.
+"""
+
+import os
+import warnings
 
 import logging
 import time
@@ -19,6 +27,17 @@ from the_alchemiser.services.errors.exceptions import (
     DataProviderError,
     MarketDataError,
     TradingClientError,
+)
+
+if os.getenv("IMPORTERROR_ON_LEGACY") == "1":
+    raise ImportError(
+        "Legacy data_provider.py is deprecated; use unified_data_provider_facade instead."
+    )
+warnings.warn(
+    "the_alchemiser.infrastructure.data_providers.data_provider is deprecated; "
+    "use unified_data_provider_facade",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 # TODO: Phase 11 - Types available for future migration to structured data types

--- a/the_alchemiser/infrastructure/data_providers/unified_data_provider_facade.py
+++ b/the_alchemiser/infrastructure/data_providers/unified_data_provider_facade.py
@@ -183,8 +183,8 @@ class UnifiedDataProviderFacade:
             self._error_handler.log_and_handle(e, {"symbol": symbol}, None)
             return None
 
-    @handle_service_errors(default_return={})
-    def get_account_info(self, **kwargs: Any) -> dict[str, Any]:
+    @handle_service_errors(default_return=None)
+    def get_account_info(self, **kwargs: Any) -> dict[str, Any] | None:
         """
         Get account information - maintains exact original interface.
 
@@ -192,13 +192,13 @@ class UnifiedDataProviderFacade:
             **kwargs: Additional arguments for backward compatibility
 
         Returns:
-            Dictionary with account information
+            Dictionary with account information or None on failure
         """
         account_model = self._account_service.get_account_info()
         if account_model:
             # Convert TypedDict to plain dict for broader compatibility
             return cast(dict[str, Any], dict(account_model.to_dict()))
-        return {}
+        return None
 
     @handle_service_errors(default_return=[])
     def get_positions(self, **kwargs: Any) -> list[dict[str, Any]]:

--- a/the_alchemiser/interface/cli/signal_analyzer.py
+++ b/the_alchemiser/interface/cli/signal_analyzer.py
@@ -11,7 +11,7 @@ from the_alchemiser.application.mapping.strategy_signal_mapping import (
 )
 from the_alchemiser.domain.strategies.strategy_manager import MultiStrategyManager, StrategyType
 from the_alchemiser.infrastructure.config import Settings
-from the_alchemiser.infrastructure.data_providers.data_provider import UnifiedDataProvider
+from the_alchemiser.infrastructure.data_providers.unified_data_provider_facade import UnifiedDataProvider
 from the_alchemiser.infrastructure.logging.logging_utils import get_logger
 from the_alchemiser.interface.cli.cli_formatter import (
     render_footer,

--- a/tools/ci/check_no_legacy_dataprovider.sh
+++ b/tools/ci/check_no_legacy_dataprovider.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if grep -R "the_alchemiser\.infrastructure\.data_providers\.data_provider" -n \
+    --exclude="swap_to_facade.py" \
+    --exclude="test_data_provider_parity.py" \
+    --exclude="data_provider.py" \
+    --exclude-dir="__pycache__" .; then
+    echo "legacy data_provider import detected" >&2
+    exit 1
+fi

--- a/tools/codemods/swap_to_facade.py
+++ b/tools/codemods/swap_to_facade.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Rewrite imports to use the data provider facade."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+TARGET = "the_alchemiser.infrastructure.data_providers.data_provider"
+REPLACEMENT = "the_alchemiser.infrastructure.data_providers.unified_data_provider_facade"
+
+
+def swap(root: Path, dry_run: bool = False) -> list[Path]:
+    """Swap legacy provider imports for facade imports."""
+    changed: list[Path] = []
+    for path in root.rglob("*.py"):
+        if "tests/contracts" in str(path) or path.resolve() == Path(__file__).resolve():
+            continue
+        text = path.read_text()
+        if TARGET in text:
+            changed.append(path)
+            if not dry_run:
+                path.write_text(text.replace(TARGET, REPLACEMENT))
+    return changed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="show files but make no changes")
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[2]
+    files = swap(root, dry_run=args.dry_run)
+    if files:
+        print("Updated imports in:")
+        for f in files:
+            print(f.relative_to(root))
+    else:
+        print("No legacy imports found")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- bind DI container to UnifiedDataProvider facade
- add contract tests covering legacy provider and facade
- add CLI smoke tests and guard script for legacy provider imports

## Testing
- `pytest tests/contracts/test_data_provider_parity.py -q`
- `pytest tests/e2e/test_cli_trade.py -q`
- `bash tools/ci/check_no_legacy_dataprovider.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a0e52d5bd8833394fd6a6e7beed969