### PR TITLE
fix: rename copilot setup steps job

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 jobs:
-  setup:
+  copilot-setup-steps:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- rename workflow job to `copilot-setup-steps` for Copilot compatibility

## Testing
- `pre-commit run --files .github/workflows/copilot-setup-steps.yml`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'the_alchemiser')*


------
https://chatgpt.com/codex/tasks/task_e_68a4e65446f4833380023b08e7af68cf