### PR TITLE
Annotate modules with business unit docstrings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,11 @@ Rules for this repo (enforced):
 - Use assert_close()/numpy.testing.assert_allclose for numerical comparisons.
 - Do NOT create tests or use testing frameworks - testing is not required for this project.
 - Suggestions that violate the above must be rewritten.
+- Every new module must start with a docstring stating its **Business Unit**
+  (strategy & signal generation, portfolio assessment & management, order
+  execution/placement, or utilities) and whether it is **current** or
+  **legacy**. Keep `BUSINESS_UNITS_REPORT.md` up to date when files are added
+  or removed.
 
 ## Overview
 The Alchemiser is a sophisticated multi-strategy quantitative trading system built with modern Python practices and Domain-Driven Design (DDD) architecture, deployed as AWS Lambda functions.

--- a/BUSINESS_UNITS_REPORT.json
+++ b/BUSINESS_UNITS_REPORT.json
@@ -1,0 +1,1814 @@
+[
+  {
+    "file": "examples/policy_layer_usage.py",
+    "business_unit": "utilities",
+    "status": "legacy",
+    "description": "Functions: example_policy_usage, execute_order, get_trading_client, get_data_provider, fractionability_only_example, canonical_executor_integration, get_alpaca_repository"
+  },
+  {
+    "file": "scripts/update_docstrings.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: classify, status"
+  },
+  {
+    "file": "the_alchemiser/main.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: TradingSystem; Functions: _resolve_log_level, configure_application_logging, create_argument_parser, main"
+  },
+  {
+    "file": "the_alchemiser/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/lambda_handler.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: parse_event_mode, lambda_handler"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/container/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/container/config_providers.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ConfigProviders"
+  },
+  {
+    "file": "the_alchemiser/container/infrastructure_providers.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: InfrastructureProviders"
+  },
+  {
+    "file": "the_alchemiser/container/service_providers.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ServiceProviders"
+  },
+  {
+    "file": "the_alchemiser/container/application_container.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ApplicationContainer"
+  },
+  {
+    "file": "the_alchemiser/execution/account_service.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: DataProvider, AccountService"
+  },
+  {
+    "file": "the_alchemiser/application/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/types.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AccountInfo, PortfolioHistoryData, ClosedPositionData, EnrichedAccountInfo, PositionInfo, OrderDetails, StrategySignalBase, StrategySignal, StrategyPnLSummary, StrategyPositionData, KLMVariantResult, KLMDecision, MarketDataPoint, IndicatorData, PriceData, QuoteData, DataProviderResult, TradeAnalysis, PortfolioSnapshot, ErrorContext, AlpacaOrderProtocol, AlpacaOrderObject"
+  },
+  {
+    "file": "the_alchemiser/interfaces/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/ports/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: MarketData, OrderExecution, RiskChecks, PositionStore, Clock, Notifier"
+  },
+  {
+    "file": "the_alchemiser/services/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/utils/serialization.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: _ModelDumpProtocol; Functions: _is_model_dump_obj, to_serializable, ensure_serialized_dict"
+  },
+  {
+    "file": "the_alchemiser/utils/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/utils/num.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: floats_equal"
+  },
+  {
+    "file": "the_alchemiser/utils/common.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ActionType"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/config/execution_config.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: ExecutionConfig; Functions: get_execution_config, reload_execution_config, create_strategy_config"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/config/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/config/config_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: load_alert_config"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/config/config.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: LoggingSettings, AlpacaSettings, AwsSettings, AlertsSettings, SecretsManagerSettings, StrategySettings, EmailSettings, DataSettings, TrackingSettings, ExecutionSettings, Settings; Functions: load_settings"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/secrets/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/secrets/secrets_manager.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: SecretsManager"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/adapters/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/logging/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/logging/logging_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AlchemiserLoggerAdapter, StructuredFormatter; Functions: get_logger, set_request_id, set_error_id, get_request_id, get_error_id, generate_request_id, log_with_context, setup_logging, configure_test_logging, configure_production_logging, get_service_logger, get_trading_logger, log_trade_event, log_error_with_context"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/alerts/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/alerts/alert_service.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: Alert; Functions: create_alert, create_alerts_from_signal, log_alert_to_file, log_alerts_to_file"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/validation/indicator_validator.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: IndicatorValidationSuite"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/validation/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/s3/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/s3/s3_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: S3Handler, S3FileHandler; Functions: get_s3_handler, replace_file_handlers_with_s3"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/websocket/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/websocket/websocket_order_monitor.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderCompletionMonitor"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/websocket/websocket_connection_manager.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: WebSocketConnectionManager"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/services/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/services/tick_size_service.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: TickSizeProvider, DynamicTickSizeService; Functions: create_tick_size_service, resolve_tick_size"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/services/slippage_analyzer.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: SlippageAnalysis, SlippageAnalyzer; Functions: create_slippage_analyzer"
+  },
+  {
+    "file": "the_alchemiser/infrastructure/data_providers/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/infrastructure/data_providers/real_time_pricing.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: RealTimeQuote, RealTimePricingService, RealTimePricingManager"
+  },
+  {
+    "file": "the_alchemiser/application/reporting/reporting.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: create_execution_summary, save_dashboard_data, build_portfolio_state_data"
+  },
+  {
+    "file": "the_alchemiser/application/reporting/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/execution/order_lifecycle_adapter.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingClientProtocol, WebSocketOrderLifecycleAdapter"
+  },
+  {
+    "file": "the_alchemiser/application/execution/execution_manager.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: ExecutionManager"
+  },
+  {
+    "file": "the_alchemiser/application/execution/spread_assessment.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: SpreadQuality, PreMarketConditions, SpreadAnalysis, SpreadAssessment"
+  },
+  {
+    "file": "the_alchemiser/application/execution/canonical_integration_example.py",
+    "business_unit": "order execution/placement",
+    "status": "legacy",
+    "description": "Functions: dto_to_domain_order_request, execute_order_with_canonical_path, example_integration"
+  },
+  {
+    "file": "the_alchemiser/application/execution/smart_execution.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderExecutor, DataProvider, SmartExecution; Functions: is_market_open"
+  },
+  {
+    "file": "the_alchemiser/application/execution/smart_pricing_handler.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: SmartPricingHandler"
+  },
+  {
+    "file": "the_alchemiser/application/execution/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/execution/canonical_executor.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: CanonicalOrderExecutor"
+  },
+  {
+    "file": "the_alchemiser/application/execution/order_request_builder.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderRequestBuilder"
+  },
+  {
+    "file": "the_alchemiser/application/trading/bootstrap.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingBootstrapContext; Functions: bootstrap_from_container, bootstrap_from_service_manager, bootstrap_traditional"
+  },
+  {
+    "file": "the_alchemiser/application/trading/alpaca_client.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: AlpacaClient"
+  },
+  {
+    "file": "the_alchemiser/application/trading/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/trading/ports.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: AccountReadPort, OrderExecutionPort, StrategyAdapterPort, RebalancingOrchestratorPort, ReportingPort"
+  },
+  {
+    "file": "the_alchemiser/application/trading/engine_service.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: AccountInfoProvider, PositionProvider, PriceProvider, RebalancingService, MultiStrategyExecutor, TradingEngine; Functions: _create_default_account_info, main"
+  },
+  {
+    "file": "the_alchemiser/application/trading/portfolio_calculations.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: AllocationComparison; Functions: _to_decimal, calculate_target_vs_current_allocations, build_allocation_comparison"
+  },
+  {
+    "file": "the_alchemiser/application/trading/account_facade.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: AccountFacade; Functions: _create_default_account_info"
+  },
+  {
+    "file": "the_alchemiser/application/policies/policy_factory.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PolicyFactory"
+  },
+  {
+    "file": "the_alchemiser/application/policies/buying_power_policy_impl.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: BuyingPowerPolicyImpl"
+  },
+  {
+    "file": "the_alchemiser/application/policies/fractionability_policy_impl.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: FractionabilityPolicyImpl"
+  },
+  {
+    "file": "the_alchemiser/application/policies/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/policies/policy_orchestrator.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PolicyOrchestrator"
+  },
+  {
+    "file": "the_alchemiser/application/policies/position_policy_impl.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PositionPolicyImpl"
+  },
+  {
+    "file": "the_alchemiser/application/policies/risk_policy_impl.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: RiskPolicyImpl"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/account_mapping.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AccountMetrics, AccountSummaryTyped; Functions: to_money_usd, account_summary_to_typed, account_typed_to_serializable"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/alpaca_dto_mapping.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: alpaca_order_to_dto, alpaca_dto_to_execution_result, alpaca_order_to_execution_result, create_error_execution_result, alpaca_exception_to_error_dto"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/tracking_mapping.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: strategy_order_to_event_dto, event_dto_to_strategy_order_dict, orders_to_execution_summary_dto, strategy_pnl_to_dict, dict_to_strategy_pnl_dict, normalize_timestamp, ensure_decimal_precision, strategy_order_dataclass_to_dto, strategy_order_dto_to_dataclass_dict, strategy_position_dataclass_to_dto, strategy_position_dto_to_dataclass_dict, strategy_pnl_dataclass_to_dto, strategy_pnl_dto_to_dataclass_dict, strategy_pnl_dto_to_dict"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/tracking.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: strategy_order_event_dto_to_dict, strategy_execution_summary_dto_to_dict, dict_to_strategy_order_event_dto, dict_to_strategy_execution_summary_dto"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/strategy_domain_mapping.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Functions: dto_to_strategy_signal_model, strategy_signal_model_to_dto, dto_to_strategy_position_model, strategy_position_model_to_dto, map_strategy_signals_to_models, map_strategy_models_to_dtos, map_strategy_positions_to_models, map_strategy_position_models_to_dtos, normalize_legacy_signal_dict"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/execution.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Functions: _to_decimal, ensure_money, ensure_quantity, _normalize_timestamp_str, _get_attr, _normalize_order_details, _normalize_orders, execution_result_dto_to_dict, dict_to_execution_result_dto, trading_plan_dto_to_dict, dict_to_trading_plan_dto, websocket_result_dto_to_dict, dict_to_websocket_result_dto, quote_dto_to_dict, dict_to_quote_dto, lambda_event_dto_to_dict, dict_to_lambda_event_dto, order_history_dto_to_dict, dict_to_order_history_dto, account_info_to_execution_result_dto, create_trading_plan_dto, create_quote_dto"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/order_mapping.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderSummary; Functions: _coerce_decimal, _map_status, alpaca_order_to_domain, summarize_order, order_to_dict, raw_order_envelope_to_domain_order, raw_order_envelope_to_execution_result_dto"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/mapping/position_mapping.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PositionSummary; Functions: _to_decimal, alpaca_position_to_summary"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/tracking_normalization.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: ensure_price, normalize_tracking_order, normalize_pnl_summary"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/market_data_mappers.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: _parse_ts, bars_to_domain, quote_to_domain"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/orders.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Functions: normalize_order_status, dict_to_order_request_dto, order_request_to_validated_dto, validated_dto_to_dict, validated_dto_to_order_handler_params, order_request_dto_to_domain_order_params, domain_order_to_execution_result_dto"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/strategy_signal_mapping.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Functions: _normalize_action, legacy_signal_to_typed, map_signals_dict, typed_dict_to_domain_signal, convert_signals_dict_to_domain, typed_strategy_signal_to_validated_order"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/policy_mapping.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: dto_to_domain_order_request, domain_order_request_to_dto, domain_warning_to_dto, dto_warning_to_domain, domain_result_to_dto, dto_to_domain_result"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/pandas_time_series.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: bars_to_dataframe"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/strategy_market_data_adapter.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategyMarketDataAdapter"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/strategies.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: StrategySignalDisplayDTO; Functions: handle_portfolio_symbol_alias, format_strategy_signal_for_display, create_empty_signal_dict, typed_signals_to_display_signals_dict, compute_consolidated_portfolio, run_all_strategies_mapping"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/market_data_mapping.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: bars_to_dataframe, quote_to_tuple, symbol_str_to_symbol, quote_to_current_price, dataframe_to_bars"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/trading_service_dto_mapping.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Functions: position_summary_to_dto, dict_to_position_summary_dto, dict_to_portfolio_summary_dto, dict_to_close_position_dto, dict_to_position_analytics_dto, dict_to_position_metrics_dto, account_summary_typed_to_dto, dict_to_enriched_account_summary_dto, dict_to_buying_power_dto, dict_to_risk_metrics_dto, dict_to_trade_eligibility_dto, dict_to_portfolio_allocation_dto, dict_to_price_dto, dict_to_price_history_dto, dict_to_spread_analysis_dto, dict_to_market_status_dto, dict_to_multi_symbol_quotes_dto, dict_to_order_cancellation_dto, dict_to_order_status_dto, dict_to_operation_result_dto, list_to_open_orders_dto, list_to_enriched_positions_dto"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/portfolio_rebalancing_mapping.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Functions: dto_to_domain_rebalance_plan, dto_plans_to_domain, rebalance_plans_dict_to_collection_dto, rebalancing_summary_dict_to_dto, rebalancing_impact_dict_to_dto, rebalance_instruction_dict_to_dto, rebalance_execution_result_dict_to_dto, safe_rebalancing_summary_dict_to_dto, safe_rebalancing_impact_dict_to_dto"
+  },
+  {
+    "file": "the_alchemiser/application/mapping/execution_summary_mapping.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Functions: dict_to_allocation_summary_dto, dict_to_strategy_pnl_summary_dto, dict_to_strategy_summary_dto, dict_to_trading_summary_dto, dict_to_execution_summary_dto, dict_to_portfolio_state_dto, safe_dict_to_execution_summary_dto, safe_dict_to_portfolio_state_dto"
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/rebalancing_orchestrator_facade.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: RebalancingOrchestratorFacade"
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/rebalancing_orchestrator.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: RebalancingOrchestrator"
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/__init__.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/portfolio_pnl_utils.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Functions: calculate_strategy_pnl_summary, extract_trading_summary, build_strategy_summary, build_allocation_summary"
+  },
+  {
+    "file": "the_alchemiser/application/tracking/strategy_order_tracker.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategyOrder, StrategyPosition, StrategyPnL, StrategyOrderTracker; Functions: get_strategy_tracker"
+  },
+  {
+    "file": "the_alchemiser/application/tracking/integration.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: StrategyExecutionContext, StrategyTrackingMixin; Functions: strategy_execution_context, track_order_execution, get_current_strategy_context, create_strategy_aware_order_callback, extract_order_details_from_alpaca_order, track_alpaca_order_if_filled, configure_strategy_tracking_integration"
+  },
+  {
+    "file": "the_alchemiser/application/tracking/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/orders/order_validation.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderValidationError, RiskLimits, ValidationResult, OrderValidator; Functions: validate_order_list"
+  },
+  {
+    "file": "the_alchemiser/application/orders/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/orders/progressive_order_utils.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderExecutionParams, ProgressiveOrderCalculator; Functions: get_market_urgency_level"
+  },
+  {
+    "file": "the_alchemiser/application/orders/order_validation_utils.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Functions: validate_quantity, validate_notional, validate_order_parameters, round_quantity_for_asset"
+  },
+  {
+    "file": "the_alchemiser/application/orders/asset_order_handler.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: AssetOrderHandler"
+  },
+  {
+    "file": "the_alchemiser/application/execution/strategies/aggressive_limit_strategy.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: ExecutionContext, AggressiveLimitStrategy"
+  },
+  {
+    "file": "the_alchemiser/application/execution/strategies/execution_context_adapter.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: ExecutionContextAdapter"
+  },
+  {
+    "file": "the_alchemiser/application/execution/strategies/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/execution/strategies/repeg_strategy.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: AttemptPlan, AttemptResult, AttemptState, RepegStrategy"
+  },
+  {
+    "file": "the_alchemiser/application/execution/strategies/config.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: StrategyConfig, StrategyConfigProvider"
+  },
+  {
+    "file": "the_alchemiser/application/trading/lifecycle/observers.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: LoggingObserver, MetricsObserver"
+  },
+  {
+    "file": "the_alchemiser/application/trading/lifecycle/cli_observer_interface.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: CLILifecycleObserver, CLIObserverAdapter"
+  },
+  {
+    "file": "the_alchemiser/application/trading/lifecycle/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/trading/lifecycle/manager.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderLifecycleManager"
+  },
+  {
+    "file": "the_alchemiser/application/trading/lifecycle/dispatcher.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: LifecycleEventDispatcher"
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/services/__init__.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/services/portfolio_rebalancing_service.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: PortfolioRebalancingService"
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/services/portfolio_management_facade.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: PortfolioManagementFacade"
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/services/portfolio_analysis_service.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: PortfolioAnalysisService"
+  },
+  {
+    "file": "the_alchemiser/application/portfolio/services/rebalance_execution_service.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: RebalanceExecutionService"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/market_data/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/parser.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: Vector, DSLParser"
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/evaluator.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: DSLEvaluator"
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/evaluator_cache.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: EvalContext, NodeEvaluationCache; Functions: create_eval_context, get_memo_stats, clear_memo_stats, is_pure_node, _structural_key, _stable_value, ensure_node_id"
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/strategy_loader.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategyLoader, StrategyResult"
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/ast.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ASTNode, NumberLiteral, Symbol, GreaterThan, LessThan, If, RSI, MovingAveragePrice, MovingAverageReturn, CumulativeReturn, CurrentPrice, StdevReturn, Asset, Group, WeightEqual, WeightSpecified, WeightInverseVolatility, Filter, SelectTop, SelectBottom, FunctionCall, Strategy"
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/optimization_config.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: DSLOptimizationConfig; Functions: _env_bool, _env_int, _env_parallel_enabled, _env_parallel_mode, get_default_config, set_default_config, configure_from_environment, get_optimization_stats"
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/errors.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: DSLError, ParseError, SchemaError, EvaluationError, SecurityError, IndicatorError, PortfolioError"
+  },
+  {
+    "file": "the_alchemiser/domain/dsl/interning.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: node_key, _stable_value, intern_node, _compute_node_id, canonicalise_ast, _canonicalise_recursive, _canonicalise_value, get_intern_stats, clear_intern_stats, clear_intern_pool"
+  },
+  {
+    "file": "the_alchemiser/domain/registry/strategy_registry.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategyType, StrategyConfig, StrategyRegistry"
+  },
+  {
+    "file": "the_alchemiser/domain/registry/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/shared_kernel/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/shared_kernel/types.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/interfaces/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/interfaces/market_data_repository.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: MarketDataRepository"
+  },
+  {
+    "file": "the_alchemiser/domain/interfaces/trading_repository.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingRepository"
+  },
+  {
+    "file": "the_alchemiser/domain/interfaces/account_repository.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AccountRepository"
+  },
+  {
+    "file": "the_alchemiser/domain/policies/policy_result.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PolicyWarning, PolicyResult; Functions: create_approved_result, create_rejected_result"
+  },
+  {
+    "file": "the_alchemiser/domain/policies/base_policy.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: OrderPolicy"
+  },
+  {
+    "file": "the_alchemiser/domain/policies/risk_policy.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: RiskPolicy"
+  },
+  {
+    "file": "the_alchemiser/domain/policies/protocols.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: TradingClientProtocol, DataProviderProtocol"
+  },
+  {
+    "file": "the_alchemiser/domain/policies/buying_power_policy.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: BuyingPowerPolicy"
+  },
+  {
+    "file": "the_alchemiser/domain/policies/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/policies/fractionability_policy.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: FractionabilityPolicy"
+  },
+  {
+    "file": "the_alchemiser/domain/policies/position_policy.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PositionPolicy"
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/__init__.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/typed_strategy_manager.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: AggregatedSignals, TypedStrategyManager"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/nuclear_logic.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: evaluate_nuclear_strategy"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/typed_klm_ensemble_engine.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: TypedKLMStrategyEngine"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/tecl_strategy_engine.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: TECLStrategyEngine; Functions: main"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/strategy_manager.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/nuclear_typed_engine.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: NuclearTypedEngine"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/engine.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: StrategyEngine"
+  },
+  {
+    "file": "the_alchemiser/domain/services/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/services/rebalancing_policy.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: calculate_rebalance_orders"
+  },
+  {
+    "file": "the_alchemiser/domain/math/trading_math.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Functions: calculate_position_size, calculate_dynamic_limit_price, calculate_dynamic_limit_price_with_symbol, calculate_slippage_buffer, calculate_allocation_discrepancy, calculate_rebalance_amounts"
+  },
+  {
+    "file": "the_alchemiser/domain/math/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/math/indicator_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: safe_get_indicator"
+  },
+  {
+    "file": "the_alchemiser/domain/math/asset_info.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AssetType, FractionabilityDetector"
+  },
+  {
+    "file": "the_alchemiser/domain/math/math_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: calculate_stdev_returns, calculate_moving_average, calculate_moving_average_return, calculate_percentage_change, calculate_rolling_metric, safe_division, normalize_to_range, calculate_ensemble_score"
+  },
+  {
+    "file": "the_alchemiser/domain/math/market_timing_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ExecutionStrategy, MarketOpenTimingEngine"
+  },
+  {
+    "file": "the_alchemiser/domain/math/indicators.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: TechnicalIndicators"
+  },
+  {
+    "file": "the_alchemiser/domain/models/strategy.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategySignalModel, StrategyPositionModel"
+  },
+  {
+    "file": "the_alchemiser/domain/models/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/models/market_data.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: BarModel, QuoteModel, PriceDataModel; Functions: bars_to_dataframe, dataframe_to_bars"
+  },
+  {
+    "file": "the_alchemiser/domain/models/position.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PositionModel"
+  },
+  {
+    "file": "the_alchemiser/domain/models/account.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AccountModel, PortfolioHistoryModel"
+  },
+  {
+    "file": "the_alchemiser/domain/models/order.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderModel"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/lifecycle/exceptions.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: InvalidOrderStateTransitionError"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/lifecycle/protocols.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: LifecycleObserver"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/lifecycle/states.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderLifecycleState"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/lifecycle/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/trading/lifecycle/events.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: LifecycleEventType, OrderLifecycleEvent"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/lifecycle/transitions.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/trading/protocols/order_lifecycle.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderLifecycleMonitor"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/protocols/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/trading/protocols/trading_repository.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingRepository"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/symbol.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: Symbol"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/order_type.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderType"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/order_request.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderRequest"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/quantity.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: Quantity"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/order_id.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderId"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/order_status.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderStatus"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/side.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: Side"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/time_in_force.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TimeInForce"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/value_objects/order_status_literal.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/trading/errors/error_codes.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderErrorCode"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/errors/classifier.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: ClassificationRule, OrderErrorClassifier; Functions: classify_exception, classify_alpaca_error, classify_validation_failure"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/errors/order_error.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderError; Functions: get_remediation_hint"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/errors/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/trading/errors/error_categories.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderErrorCategory"
+  },
+  {
+    "file": "the_alchemiser/domain/trading/entities/order.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: Order"
+  },
+  {
+    "file": "the_alchemiser/domain/market_data/protocols/market_data_port.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: MarketDataPort"
+  },
+  {
+    "file": "the_alchemiser/domain/market_data/models/quote.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: QuoteModel"
+  },
+  {
+    "file": "the_alchemiser/domain/market_data/models/bar.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: BarModel"
+  },
+  {
+    "file": "the_alchemiser/domain/shared_kernel/value_objects/identifier.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: Identifier"
+  },
+  {
+    "file": "the_alchemiser/domain/shared_kernel/value_objects/symbol.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: Symbol"
+  },
+  {
+    "file": "the_alchemiser/domain/shared_kernel/value_objects/money.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: Money"
+  },
+  {
+    "file": "the_alchemiser/domain/shared_kernel/value_objects/percentage.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: Percentage"
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/strategy_attribution/symbol_classifier.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: SymbolClassifier"
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/strategy_attribution/__init__.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/strategy_attribution/attribution_engine.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategyAttributionEngine"
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/position/position_analyzer.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: PositionAnalyzer"
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/position/position_delta.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: PositionDelta"
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/position/__init__.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/rebalancing/rebalance_plan.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: RebalancePlan"
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/rebalancing/__init__.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/portfolio/rebalancing/rebalance_calculator.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: RebalanceCalculator"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/protocols/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/protocols/strategy_engine.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategyEngine"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/value_objects/alert.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: Alert"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/value_objects/strategy_signal.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategySignal"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/value_objects/confidence.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: Confidence"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/variant_506_38.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: KlmVariant50638"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/variant_1200_28.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: KlmVariant120028"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/variant_nova.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: KLMVariantNova"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/base_klm_variant.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: BaseKLMVariant"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/variant_520_22.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: KlmVariant52022"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/variant_410_38.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: KlmVariant41038"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/variant_530_18.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: KlmVariant53018"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/variant_830_21.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: KlmVariant83021"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/klm_workers/variant_1280_26.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: KlmVariant128026"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/entities/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/models/strategy_position_model.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategyPositionModel"
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/models/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/domain/strategies/models/strategy_signal_model.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategySignalModel"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/cli.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: CLIOptions, CLICommandResult, CLISignalData, CLIAccountDisplay, CLIPortfolioData, CLIOrderDisplay"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/smart_trading.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderValidationMetadataDTO, SmartOrderExecutionDTO, TradingDashboardDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/tracking.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: OrderEventStatus, ExecutionStatus, StrategyValidationMixin, StrategyOrderEventDTO, StrategyOrderDTO, StrategyPositionDTO, StrategyPnLDTO, StrategyExecutionSummaryDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/execution.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingAction, WebSocketStatus, ExecutionResultDTO, TradingPlanDTO, WebSocketResultDTO, QuoteDTO, LambdaEventDTO, OrderHistoryDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/reporting.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: DashboardMetrics, ReportingData, EmailReportData, EmailCredentials, EmailSummary, BacktestResult, PerformanceMetrics"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/execution_summary.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: AllocationSummaryDTO, StrategyPnLSummaryDTO, StrategySummaryDTO, TradingSummaryDTO, ExecutionSummaryDTO, PortfolioStateDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/enriched_data.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: EnrichedOrderDTO, OpenOrdersDTO, EnrichedPositionDTO, EnrichedPositionsDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/orders.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderValidationMixin, OrderRequestDTO, ValidatedOrderDTO, OrderExecutionResultDTO, LimitOrderResultDTO, RawOrderEnvelope, AdjustedOrderRequestDTO, PolicyWarningDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/market_data.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PriceDTO, PriceHistoryDTO, SpreadAnalysisDTO, MarketStatusDTO, MultiSymbolQuotesDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/base.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ResultDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/common.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: MultiStrategyExecutionResultDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/portfolio_rebalancing.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: RebalancePlanDTO, RebalancePlanCollectionDTO, RebalancingSummaryDTO, RebalancingImpactDTO, RebalanceInstructionDTO, RebalanceExecutionResultDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/alpaca.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AlpacaOrderDTO, AlpacaErrorDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/accounts.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AccountSummaryDTO, AccountMetricsDTO, BuyingPowerDTO, RiskMetricsDTO, TradeEligibilityDTO, PortfolioAllocationDTO, EnrichedAccountSummaryDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/operations.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: OperationResultDTO, OrderCancellationDTO, OrderStatusDTO"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/errors.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ErrorDetailInfo, ErrorSummaryData, ErrorReportSummary, ErrorNotificationData, ErrorContextData"
+  },
+  {
+    "file": "the_alchemiser/interfaces/schemas/positions.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PositionDTO, PositionSummaryDTO, PortfolioSummaryDTO, PortfolioMetricsDTO, PositionAnalyticsDTO, PositionMetricsDTO, LargestPositionDTO, ClosePositionResultDTO, PortfolioValueDTO"
+  },
+  {
+    "file": "the_alchemiser/services/repository/alpaca_manager.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AlpacaManager; Functions: create_alpaca_manager"
+  },
+  {
+    "file": "the_alchemiser/services/repository/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/services/trading/position_manager.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: PositionManager"
+  },
+  {
+    "file": "the_alchemiser/services/trading/trading_client_service.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingClientService"
+  },
+  {
+    "file": "the_alchemiser/services/trading/__init__.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/services/trading/order_service.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: OrderType, OrderValidationError, OrderOperationError, OrderService"
+  },
+  {
+    "file": "the_alchemiser/services/trading/position_service.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: PositionInfo, PortfolioSummary, PositionValidationError, PositionService"
+  },
+  {
+    "file": "the_alchemiser/services/trading/trading_service_manager.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingServiceManager"
+  },
+  {
+    "file": "the_alchemiser/services/market_data/streaming_service.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: _RealTimePricingProtocol, StreamingService"
+  },
+  {
+    "file": "the_alchemiser/services/market_data/price_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: ensure_scalar_price"
+  },
+  {
+    "file": "the_alchemiser/services/market_data/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/services/market_data/market_data_client.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: MarketDataClient"
+  },
+  {
+    "file": "the_alchemiser/services/market_data/strategy_market_data_service.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: StrategyMarketDataService"
+  },
+  {
+    "file": "the_alchemiser/services/market_data/price_fetching_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: subscribe_for_real_time, extract_bid_ask, calculate_price_from_bid_ask, get_price_from_quote_api, get_price_from_historical_fallback, create_cleanup_function"
+  },
+  {
+    "file": "the_alchemiser/services/market_data/market_data_service.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: MarketDataService"
+  },
+  {
+    "file": "the_alchemiser/services/market_data/price_service.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ModernPriceFetchingService"
+  },
+  {
+    "file": "the_alchemiser/services/errors/handler.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ErrorSeverity, ErrorCategory, ErrorDetails, EnhancedAlchemiserError, TradingSystemErrorHandler, EnhancedTradingError, EnhancedDataError, CircuitBreakerOpenError, CircuitBreaker, EnhancedErrorReporter; Functions: get_error_handler, handle_trading_error, send_error_notification_if_needed, retry_with_backoff, categorize_error_severity, create_enhanced_error, get_enhanced_error_reporter, get_global_error_reporter, handle_errors_with_retry"
+  },
+  {
+    "file": "the_alchemiser/services/errors/error_recovery.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: RecoveryResult, ErrorRecoveryStrategy, TradingErrorRecovery, DataErrorRecovery, CircuitState, CircuitBreakerOpenError, CircuitBreaker, RetryStrategy, ExponentialBackoffStrategy, LinearBackoffStrategy, FixedIntervalStrategy, FibonacciBackoffStrategy, SmartRetryManager, ErrorRecoveryManager; Functions: get_recovery_manager, with_circuit_breaker, with_retry, with_resilience"
+  },
+  {
+    "file": "the_alchemiser/services/errors/exceptions.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AlchemiserError, ConfigurationError, DataProviderError, TradingClientError, OrderExecutionError, OrderPlacementError, OrderTimeoutError, SpreadAnalysisError, BuyingPowerError, InsufficientFundsError, PositionValidationError, StrategyExecutionError, IndicatorCalculationError, MarketDataError, ValidationError, NotificationError, S3OperationError, RateLimitError, MarketClosedError, WebSocketError, StreamingError, LoggingError, FileOperationError, DatabaseError, SecurityError, EnvironmentError"
+  },
+  {
+    "file": "the_alchemiser/services/errors/error_reporter.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ErrorReporter; Functions: get_error_reporter, report_error_globally"
+  },
+  {
+    "file": "the_alchemiser/services/errors/error_handling.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ErrorHandler, ServiceMetrics, ErrorContext; Functions: create_service_logger, _deprecated_decorator_stub, _deprecated_instance_stub, with_metrics"
+  },
+  {
+    "file": "the_alchemiser/services/errors/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/services/errors/decorators.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: translate_service_errors, translate_market_data_errors, translate_trading_errors, translate_streaming_errors, translate_config_errors"
+  },
+  {
+    "file": "the_alchemiser/services/errors/scope.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: _ScopeErrorHandler, ErrorScope; Functions: create_error_scope"
+  },
+  {
+    "file": "the_alchemiser/services/errors/context.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ErrorContextData; Functions: create_error_context"
+  },
+  {
+    "file": "the_alchemiser/services/errors/error_monitoring.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: HealthStatus, ErrorEvent, RecoveryStats, ErrorMetricsCollector, AlertThresholdManager, HealthReport, ErrorHealthDashboard, ProductionMonitor; Functions: get_production_monitor, record_error_for_monitoring, record_recovery_for_monitoring, get_system_health, get_health_dashboard"
+  },
+  {
+    "file": "the_alchemiser/services/account/account_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: extract_comprehensive_account_data, extract_basic_account_metrics, calculate_position_target_deltas, extract_current_position_values"
+  },
+  {
+    "file": "the_alchemiser/services/account/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/services/account/account_service.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: AccountService"
+  },
+  {
+    "file": "the_alchemiser/services/shared/config_service.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ConfigService"
+  },
+  {
+    "file": "the_alchemiser/services/shared/service_factory.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ServiceFactory"
+  },
+  {
+    "file": "the_alchemiser/services/shared/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/services/shared/retry_decorator.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: retry_with_backoff, retry_api_call, retry_data_fetch, retry_order_execution"
+  },
+  {
+    "file": "the_alchemiser/services/shared/cache_manager.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: CacheManager"
+  },
+  {
+    "file": "the_alchemiser/services/shared/secrets_service.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: SecretsService"
+  },
+  {
+    "file": "the_alchemiser/interface/cli/signal_analyzer.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: SignalAnalyzer"
+  },
+  {
+    "file": "the_alchemiser/interface/cli/cli.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: show_welcome, signal, trade, status, dsl_count, deploy, version, validate_indicators, main"
+  },
+  {
+    "file": "the_alchemiser/interface/cli/signal_display_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: display_signal_results, display_typed_signal_results, display_signal_results_unified, display_technical_indicators, display_portfolio_details"
+  },
+  {
+    "file": "the_alchemiser/interface/cli/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/interface/cli/cli_formatter.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: render_technical_indicators, render_strategy_signals, render_portfolio_allocation, render_orders_executed, _format_money, render_account_info, render_header, render_footer, render_target_vs_current_allocations, render_execution_plan, render_enriched_order_summaries, render_multi_strategy_summary"
+  },
+  {
+    "file": "the_alchemiser/interface/cli/trading_executor.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingExecutor"
+  },
+  {
+    "file": "the_alchemiser/interface/cli/portfolio_calculations.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Functions: calculate_target_vs_current_allocations"
+  },
+  {
+    "file": "the_alchemiser/interface/cli/error_display_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: render_order_error, render_order_errors_table, render_error_summary, format_error_for_notification, _get_error_severity"
+  },
+  {
+    "file": "the_alchemiser/interface/cli/dashboard_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: build_basic_dashboard_structure, extract_portfolio_metrics, extract_positions_data, extract_strategies_data, extract_recent_trades_data, build_s3_paths"
+  },
+  {
+    "file": "the_alchemiser/interface/email/client.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: EmailClient; Functions: send_email_notification"
+  },
+  {
+    "file": "the_alchemiser/interface/email/email_utils.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Functions: _build_portfolio_display, _build_closed_positions_pnl_email_html, _build_technical_indicators_email_html, _build_detailed_strategy_signals_email_html, _build_enhanced_trading_summary_email_html, _build_enhanced_portfolio_email_html"
+  },
+  {
+    "file": "the_alchemiser/interface/email/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": ""
+  },
+  {
+    "file": "the_alchemiser/interface/email/config.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: EmailConfig; Functions: get_email_config, is_neutral_mode_enabled"
+  },
+  {
+    "file": "the_alchemiser/interface/email/templates/performance.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: PerformanceBuilder"
+  },
+  {
+    "file": "the_alchemiser/interface/email/templates/multi_strategy.py",
+    "business_unit": "strategy & signal generation",
+    "status": "current",
+    "description": "Classes: MultiStrategyReportBuilder"
+  },
+  {
+    "file": "the_alchemiser/interface/email/templates/__init__.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: EmailTemplates; Functions: build_trading_report_html, build_multi_strategy_email_html, build_multi_strategy_email_html_neutral, build_error_email_html"
+  },
+  {
+    "file": "the_alchemiser/interface/email/templates/base.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: BaseEmailTemplate"
+  },
+  {
+    "file": "the_alchemiser/interface/email/templates/trading_report.py",
+    "business_unit": "order execution/placement",
+    "status": "current",
+    "description": "Classes: TradingReportBuilder"
+  },
+  {
+    "file": "the_alchemiser/interface/email/templates/error_report.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: ErrorReportBuilder"
+  },
+  {
+    "file": "the_alchemiser/interface/email/templates/portfolio.py",
+    "business_unit": "portfolio assessment & management",
+    "status": "current",
+    "description": "Classes: ExecutionSummaryLike, PortfolioBuilder; Functions: _normalise_result"
+  },
+  {
+    "file": "the_alchemiser/interface/email/templates/signals.py",
+    "business_unit": "utilities",
+    "status": "current",
+    "description": "Classes: SignalsBuilder"
+  }
+]

--- a/BUSINESS_UNITS_REPORT.md
+++ b/BUSINESS_UNITS_REPORT.md
@@ -1,0 +1,306 @@
+# Business Units Report
+
+| File | Business Unit | Status | Description |
+| --- | --- | --- | --- |
+| examples/policy_layer_usage.py | utilities | legacy | Functions: example_policy_usage, execute_order, get_trading_client, get_data_provider, fractionability_only_example, canonical_executor_integration, get_alpaca_repository |
+| scripts/update_docstrings.py | utilities | current | Functions: classify, status |
+| the_alchemiser/main.py | utilities | current | Classes: TradingSystem; Functions: _resolve_log_level, configure_application_logging, create_argument_parser, main |
+| the_alchemiser/__init__.py | utilities | current |  |
+| the_alchemiser/lambda_handler.py | utilities | current | Functions: parse_event_mode, lambda_handler |
+| the_alchemiser/infrastructure/__init__.py | utilities | current |  |
+| the_alchemiser/container/__init__.py | utilities | current |  |
+| the_alchemiser/container/config_providers.py | utilities | current | Classes: ConfigProviders |
+| the_alchemiser/container/infrastructure_providers.py | utilities | current | Classes: InfrastructureProviders |
+| the_alchemiser/container/service_providers.py | utilities | current | Classes: ServiceProviders |
+| the_alchemiser/container/application_container.py | utilities | current | Classes: ApplicationContainer |
+| the_alchemiser/execution/account_service.py | order execution/placement | current | Classes: DataProvider, AccountService |
+| the_alchemiser/application/__init__.py | utilities | current |  |
+| the_alchemiser/domain/__init__.py | utilities | current |  |
+| the_alchemiser/domain/types.py | utilities | current | Classes: AccountInfo, PortfolioHistoryData, ClosedPositionData, EnrichedAccountInfo, PositionInfo, OrderDetails, StrategySignalBase, StrategySignal, StrategyPnLSummary, StrategyPositionData, KLMVariantResult, KLMDecision, MarketDataPoint, IndicatorData, PriceData, QuoteData, DataProviderResult, TradeAnalysis, PortfolioSnapshot, ErrorContext, AlpacaOrderProtocol, AlpacaOrderObject |
+| the_alchemiser/interfaces/__init__.py | utilities | current |  |
+| the_alchemiser/ports/__init__.py | utilities | current | Classes: MarketData, OrderExecution, RiskChecks, PositionStore, Clock, Notifier |
+| the_alchemiser/services/__init__.py | utilities | current |  |
+| the_alchemiser/utils/serialization.py | utilities | current | Classes: _ModelDumpProtocol; Functions: _is_model_dump_obj, to_serializable, ensure_serialized_dict |
+| the_alchemiser/utils/__init__.py | utilities | current |  |
+| the_alchemiser/utils/num.py | utilities | current | Functions: floats_equal |
+| the_alchemiser/utils/common.py | utilities | current | Classes: ActionType |
+| the_alchemiser/infrastructure/config/execution_config.py | order execution/placement | current | Classes: ExecutionConfig; Functions: get_execution_config, reload_execution_config, create_strategy_config |
+| the_alchemiser/infrastructure/config/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/config/config_utils.py | utilities | current | Functions: load_alert_config |
+| the_alchemiser/infrastructure/config/config.py | utilities | current | Classes: LoggingSettings, AlpacaSettings, AwsSettings, AlertsSettings, SecretsManagerSettings, StrategySettings, EmailSettings, DataSettings, TrackingSettings, ExecutionSettings, Settings; Functions: load_settings |
+| the_alchemiser/infrastructure/secrets/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/secrets/secrets_manager.py | utilities | current | Classes: SecretsManager |
+| the_alchemiser/infrastructure/adapters/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/logging/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/logging/logging_utils.py | utilities | current | Classes: AlchemiserLoggerAdapter, StructuredFormatter; Functions: get_logger, set_request_id, set_error_id, get_request_id, get_error_id, generate_request_id, log_with_context, setup_logging, configure_test_logging, configure_production_logging, get_service_logger, get_trading_logger, log_trade_event, log_error_with_context |
+| the_alchemiser/infrastructure/alerts/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/alerts/alert_service.py | utilities | current | Classes: Alert; Functions: create_alert, create_alerts_from_signal, log_alert_to_file, log_alerts_to_file |
+| the_alchemiser/infrastructure/validation/indicator_validator.py | utilities | current | Classes: IndicatorValidationSuite |
+| the_alchemiser/infrastructure/validation/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/s3/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/s3/s3_utils.py | utilities | current | Classes: S3Handler, S3FileHandler; Functions: get_s3_handler, replace_file_handlers_with_s3 |
+| the_alchemiser/infrastructure/websocket/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/websocket/websocket_order_monitor.py | order execution/placement | current | Classes: OrderCompletionMonitor |
+| the_alchemiser/infrastructure/websocket/websocket_connection_manager.py | utilities | current | Classes: WebSocketConnectionManager |
+| the_alchemiser/infrastructure/services/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/services/tick_size_service.py | utilities | current | Classes: TickSizeProvider, DynamicTickSizeService; Functions: create_tick_size_service, resolve_tick_size |
+| the_alchemiser/infrastructure/services/slippage_analyzer.py | utilities | current | Classes: SlippageAnalysis, SlippageAnalyzer; Functions: create_slippage_analyzer |
+| the_alchemiser/infrastructure/data_providers/__init__.py | utilities | current |  |
+| the_alchemiser/infrastructure/data_providers/real_time_pricing.py | utilities | current | Classes: RealTimeQuote, RealTimePricingService, RealTimePricingManager |
+| the_alchemiser/application/reporting/reporting.py | utilities | current | Functions: create_execution_summary, save_dashboard_data, build_portfolio_state_data |
+| the_alchemiser/application/reporting/__init__.py | utilities | current |  |
+| the_alchemiser/application/execution/order_lifecycle_adapter.py | order execution/placement | current | Classes: TradingClientProtocol, WebSocketOrderLifecycleAdapter |
+| the_alchemiser/application/execution/execution_manager.py | order execution/placement | current | Classes: ExecutionManager |
+| the_alchemiser/application/execution/spread_assessment.py | order execution/placement | current | Classes: SpreadQuality, PreMarketConditions, SpreadAnalysis, SpreadAssessment |
+| the_alchemiser/application/execution/canonical_integration_example.py | order execution/placement | legacy | Functions: dto_to_domain_order_request, execute_order_with_canonical_path, example_integration |
+| the_alchemiser/application/execution/smart_execution.py | order execution/placement | current | Classes: OrderExecutor, DataProvider, SmartExecution; Functions: is_market_open |
+| the_alchemiser/application/execution/smart_pricing_handler.py | order execution/placement | current | Classes: SmartPricingHandler |
+| the_alchemiser/application/execution/__init__.py | order execution/placement | current |  |
+| the_alchemiser/application/execution/canonical_executor.py | order execution/placement | current | Classes: CanonicalOrderExecutor |
+| the_alchemiser/application/execution/order_request_builder.py | order execution/placement | current | Classes: OrderRequestBuilder |
+| the_alchemiser/application/trading/bootstrap.py | order execution/placement | current | Classes: TradingBootstrapContext; Functions: bootstrap_from_container, bootstrap_from_service_manager, bootstrap_traditional |
+| the_alchemiser/application/trading/alpaca_client.py | order execution/placement | current | Classes: AlpacaClient |
+| the_alchemiser/application/trading/__init__.py | order execution/placement | current |  |
+| the_alchemiser/application/trading/ports.py | order execution/placement | current | Classes: AccountReadPort, OrderExecutionPort, StrategyAdapterPort, RebalancingOrchestratorPort, ReportingPort |
+| the_alchemiser/application/trading/engine_service.py | order execution/placement | current | Classes: AccountInfoProvider, PositionProvider, PriceProvider, RebalancingService, MultiStrategyExecutor, TradingEngine; Functions: _create_default_account_info, main |
+| the_alchemiser/application/trading/portfolio_calculations.py | portfolio assessment & management | current | Classes: AllocationComparison; Functions: _to_decimal, calculate_target_vs_current_allocations, build_allocation_comparison |
+| the_alchemiser/application/trading/account_facade.py | order execution/placement | current | Classes: AccountFacade; Functions: _create_default_account_info |
+| the_alchemiser/application/policies/policy_factory.py | utilities | current | Classes: PolicyFactory |
+| the_alchemiser/application/policies/buying_power_policy_impl.py | utilities | current | Classes: BuyingPowerPolicyImpl |
+| the_alchemiser/application/policies/fractionability_policy_impl.py | utilities | current | Classes: FractionabilityPolicyImpl |
+| the_alchemiser/application/policies/__init__.py | utilities | current |  |
+| the_alchemiser/application/policies/policy_orchestrator.py | utilities | current | Classes: PolicyOrchestrator |
+| the_alchemiser/application/policies/position_policy_impl.py | utilities | current | Classes: PositionPolicyImpl |
+| the_alchemiser/application/policies/risk_policy_impl.py | utilities | current | Classes: RiskPolicyImpl |
+| the_alchemiser/application/mapping/account_mapping.py | utilities | current | Classes: AccountMetrics, AccountSummaryTyped; Functions: to_money_usd, account_summary_to_typed, account_typed_to_serializable |
+| the_alchemiser/application/mapping/alpaca_dto_mapping.py | utilities | current | Functions: alpaca_order_to_dto, alpaca_dto_to_execution_result, alpaca_order_to_execution_result, create_error_execution_result, alpaca_exception_to_error_dto |
+| the_alchemiser/application/mapping/tracking_mapping.py | utilities | current | Functions: strategy_order_to_event_dto, event_dto_to_strategy_order_dict, orders_to_execution_summary_dto, strategy_pnl_to_dict, dict_to_strategy_pnl_dict, normalize_timestamp, ensure_decimal_precision, strategy_order_dataclass_to_dto, strategy_order_dto_to_dataclass_dict, strategy_position_dataclass_to_dto, strategy_position_dto_to_dataclass_dict, strategy_pnl_dataclass_to_dto, strategy_pnl_dto_to_dataclass_dict, strategy_pnl_dto_to_dict |
+| the_alchemiser/application/mapping/tracking.py | utilities | current | Functions: strategy_order_event_dto_to_dict, strategy_execution_summary_dto_to_dict, dict_to_strategy_order_event_dto, dict_to_strategy_execution_summary_dto |
+| the_alchemiser/application/mapping/strategy_domain_mapping.py | strategy & signal generation | current | Functions: dto_to_strategy_signal_model, strategy_signal_model_to_dto, dto_to_strategy_position_model, strategy_position_model_to_dto, map_strategy_signals_to_models, map_strategy_models_to_dtos, map_strategy_positions_to_models, map_strategy_position_models_to_dtos, normalize_legacy_signal_dict |
+| the_alchemiser/application/mapping/execution.py | order execution/placement | current | Functions: _to_decimal, ensure_money, ensure_quantity, _normalize_timestamp_str, _get_attr, _normalize_order_details, _normalize_orders, execution_result_dto_to_dict, dict_to_execution_result_dto, trading_plan_dto_to_dict, dict_to_trading_plan_dto, websocket_result_dto_to_dict, dict_to_websocket_result_dto, quote_dto_to_dict, dict_to_quote_dto, lambda_event_dto_to_dict, dict_to_lambda_event_dto, order_history_dto_to_dict, dict_to_order_history_dto, account_info_to_execution_result_dto, create_trading_plan_dto, create_quote_dto |
+| the_alchemiser/application/mapping/order_mapping.py | order execution/placement | current | Classes: OrderSummary; Functions: _coerce_decimal, _map_status, alpaca_order_to_domain, summarize_order, order_to_dict, raw_order_envelope_to_domain_order, raw_order_envelope_to_execution_result_dto |
+| the_alchemiser/application/mapping/__init__.py | utilities | current |  |
+| the_alchemiser/application/mapping/position_mapping.py | utilities | current | Classes: PositionSummary; Functions: _to_decimal, alpaca_position_to_summary |
+| the_alchemiser/application/mapping/tracking_normalization.py | utilities | current | Functions: ensure_price, normalize_tracking_order, normalize_pnl_summary |
+| the_alchemiser/application/mapping/market_data_mappers.py | utilities | current | Functions: _parse_ts, bars_to_domain, quote_to_domain |
+| the_alchemiser/application/mapping/orders.py | order execution/placement | current | Functions: normalize_order_status, dict_to_order_request_dto, order_request_to_validated_dto, validated_dto_to_dict, validated_dto_to_order_handler_params, order_request_dto_to_domain_order_params, domain_order_to_execution_result_dto |
+| the_alchemiser/application/mapping/strategy_signal_mapping.py | strategy & signal generation | current | Functions: _normalize_action, legacy_signal_to_typed, map_signals_dict, typed_dict_to_domain_signal, convert_signals_dict_to_domain, typed_strategy_signal_to_validated_order |
+| the_alchemiser/application/mapping/policy_mapping.py | utilities | current | Functions: dto_to_domain_order_request, domain_order_request_to_dto, domain_warning_to_dto, dto_warning_to_domain, domain_result_to_dto, dto_to_domain_result |
+| the_alchemiser/application/mapping/pandas_time_series.py | utilities | current | Functions: bars_to_dataframe |
+| the_alchemiser/application/mapping/strategy_market_data_adapter.py | strategy & signal generation | current | Classes: StrategyMarketDataAdapter |
+| the_alchemiser/application/mapping/strategies.py | utilities | current | Classes: StrategySignalDisplayDTO; Functions: handle_portfolio_symbol_alias, format_strategy_signal_for_display, create_empty_signal_dict, typed_signals_to_display_signals_dict, compute_consolidated_portfolio, run_all_strategies_mapping |
+| the_alchemiser/application/mapping/market_data_mapping.py | utilities | current | Functions: bars_to_dataframe, quote_to_tuple, symbol_str_to_symbol, quote_to_current_price, dataframe_to_bars |
+| the_alchemiser/application/mapping/trading_service_dto_mapping.py | order execution/placement | current | Functions: position_summary_to_dto, dict_to_position_summary_dto, dict_to_portfolio_summary_dto, dict_to_close_position_dto, dict_to_position_analytics_dto, dict_to_position_metrics_dto, account_summary_typed_to_dto, dict_to_enriched_account_summary_dto, dict_to_buying_power_dto, dict_to_risk_metrics_dto, dict_to_trade_eligibility_dto, dict_to_portfolio_allocation_dto, dict_to_price_dto, dict_to_price_history_dto, dict_to_spread_analysis_dto, dict_to_market_status_dto, dict_to_multi_symbol_quotes_dto, dict_to_order_cancellation_dto, dict_to_order_status_dto, dict_to_operation_result_dto, list_to_open_orders_dto, list_to_enriched_positions_dto |
+| the_alchemiser/application/mapping/portfolio_rebalancing_mapping.py | portfolio assessment & management | current | Functions: dto_to_domain_rebalance_plan, dto_plans_to_domain, rebalance_plans_dict_to_collection_dto, rebalancing_summary_dict_to_dto, rebalancing_impact_dict_to_dto, rebalance_instruction_dict_to_dto, rebalance_execution_result_dict_to_dto, safe_rebalancing_summary_dict_to_dto, safe_rebalancing_impact_dict_to_dto |
+| the_alchemiser/application/mapping/execution_summary_mapping.py | order execution/placement | current | Functions: dict_to_allocation_summary_dto, dict_to_strategy_pnl_summary_dto, dict_to_strategy_summary_dto, dict_to_trading_summary_dto, dict_to_execution_summary_dto, dict_to_portfolio_state_dto, safe_dict_to_execution_summary_dto, safe_dict_to_portfolio_state_dto |
+| the_alchemiser/application/portfolio/rebalancing_orchestrator_facade.py | portfolio assessment & management | current | Classes: RebalancingOrchestratorFacade |
+| the_alchemiser/application/portfolio/rebalancing_orchestrator.py | portfolio assessment & management | current | Classes: RebalancingOrchestrator |
+| the_alchemiser/application/portfolio/__init__.py | portfolio assessment & management | current |  |
+| the_alchemiser/application/portfolio/portfolio_pnl_utils.py | portfolio assessment & management | current | Functions: calculate_strategy_pnl_summary, extract_trading_summary, build_strategy_summary, build_allocation_summary |
+| the_alchemiser/application/tracking/strategy_order_tracker.py | strategy & signal generation | current | Classes: StrategyOrder, StrategyPosition, StrategyPnL, StrategyOrderTracker; Functions: get_strategy_tracker |
+| the_alchemiser/application/tracking/integration.py | utilities | current | Classes: StrategyExecutionContext, StrategyTrackingMixin; Functions: strategy_execution_context, track_order_execution, get_current_strategy_context, create_strategy_aware_order_callback, extract_order_details_from_alpaca_order, track_alpaca_order_if_filled, configure_strategy_tracking_integration |
+| the_alchemiser/application/tracking/__init__.py | utilities | current |  |
+| the_alchemiser/application/orders/order_validation.py | order execution/placement | current | Classes: OrderValidationError, RiskLimits, ValidationResult, OrderValidator; Functions: validate_order_list |
+| the_alchemiser/application/orders/__init__.py | order execution/placement | current |  |
+| the_alchemiser/application/orders/progressive_order_utils.py | order execution/placement | current | Classes: OrderExecutionParams, ProgressiveOrderCalculator; Functions: get_market_urgency_level |
+| the_alchemiser/application/orders/order_validation_utils.py | order execution/placement | current | Functions: validate_quantity, validate_notional, validate_order_parameters, round_quantity_for_asset |
+| the_alchemiser/application/orders/asset_order_handler.py | order execution/placement | current | Classes: AssetOrderHandler |
+| the_alchemiser/application/execution/strategies/aggressive_limit_strategy.py | strategy & signal generation | current | Classes: ExecutionContext, AggressiveLimitStrategy |
+| the_alchemiser/application/execution/strategies/execution_context_adapter.py | order execution/placement | current | Classes: ExecutionContextAdapter |
+| the_alchemiser/application/execution/strategies/__init__.py | order execution/placement | current |  |
+| the_alchemiser/application/execution/strategies/repeg_strategy.py | strategy & signal generation | current | Classes: AttemptPlan, AttemptResult, AttemptState, RepegStrategy |
+| the_alchemiser/application/execution/strategies/config.py | order execution/placement | current | Classes: StrategyConfig, StrategyConfigProvider |
+| the_alchemiser/application/trading/lifecycle/observers.py | order execution/placement | current | Classes: LoggingObserver, MetricsObserver |
+| the_alchemiser/application/trading/lifecycle/cli_observer_interface.py | order execution/placement | current | Classes: CLILifecycleObserver, CLIObserverAdapter |
+| the_alchemiser/application/trading/lifecycle/__init__.py | order execution/placement | current |  |
+| the_alchemiser/application/trading/lifecycle/manager.py | order execution/placement | current | Classes: OrderLifecycleManager |
+| the_alchemiser/application/trading/lifecycle/dispatcher.py | order execution/placement | current | Classes: LifecycleEventDispatcher |
+| the_alchemiser/application/portfolio/services/__init__.py | portfolio assessment & management | current |  |
+| the_alchemiser/application/portfolio/services/portfolio_rebalancing_service.py | portfolio assessment & management | current | Classes: PortfolioRebalancingService |
+| the_alchemiser/application/portfolio/services/portfolio_management_facade.py | portfolio assessment & management | current | Classes: PortfolioManagementFacade |
+| the_alchemiser/application/portfolio/services/portfolio_analysis_service.py | portfolio assessment & management | current | Classes: PortfolioAnalysisService |
+| the_alchemiser/application/portfolio/services/rebalance_execution_service.py | portfolio assessment & management | current | Classes: RebalanceExecutionService |
+| the_alchemiser/domain/trading/__init__.py | order execution/placement | current |  |
+| the_alchemiser/domain/market_data/__init__.py | utilities | current |  |
+| the_alchemiser/domain/dsl/parser.py | utilities | current | Classes: Vector, DSLParser |
+| the_alchemiser/domain/dsl/evaluator.py | utilities | current | Classes: DSLEvaluator |
+| the_alchemiser/domain/dsl/__init__.py | utilities | current |  |
+| the_alchemiser/domain/dsl/evaluator_cache.py | utilities | current | Classes: EvalContext, NodeEvaluationCache; Functions: create_eval_context, get_memo_stats, clear_memo_stats, is_pure_node, _structural_key, _stable_value, ensure_node_id |
+| the_alchemiser/domain/dsl/strategy_loader.py | strategy & signal generation | current | Classes: StrategyLoader, StrategyResult |
+| the_alchemiser/domain/dsl/ast.py | utilities | current | Classes: ASTNode, NumberLiteral, Symbol, GreaterThan, LessThan, If, RSI, MovingAveragePrice, MovingAverageReturn, CumulativeReturn, CurrentPrice, StdevReturn, Asset, Group, WeightEqual, WeightSpecified, WeightInverseVolatility, Filter, SelectTop, SelectBottom, FunctionCall, Strategy |
+| the_alchemiser/domain/dsl/optimization_config.py | utilities | current | Classes: DSLOptimizationConfig; Functions: _env_bool, _env_int, _env_parallel_enabled, _env_parallel_mode, get_default_config, set_default_config, configure_from_environment, get_optimization_stats |
+| the_alchemiser/domain/dsl/errors.py | utilities | current | Classes: DSLError, ParseError, SchemaError, EvaluationError, SecurityError, IndicatorError, PortfolioError |
+| the_alchemiser/domain/dsl/interning.py | utilities | current | Functions: node_key, _stable_value, intern_node, _compute_node_id, canonicalise_ast, _canonicalise_recursive, _canonicalise_value, get_intern_stats, clear_intern_stats, clear_intern_pool |
+| the_alchemiser/domain/registry/strategy_registry.py | strategy & signal generation | current | Classes: StrategyType, StrategyConfig, StrategyRegistry |
+| the_alchemiser/domain/registry/__init__.py | utilities | current |  |
+| the_alchemiser/domain/shared_kernel/__init__.py | utilities | current |  |
+| the_alchemiser/domain/shared_kernel/types.py | utilities | current |  |
+| the_alchemiser/domain/interfaces/__init__.py | utilities | current |  |
+| the_alchemiser/domain/interfaces/market_data_repository.py | utilities | current | Classes: MarketDataRepository |
+| the_alchemiser/domain/interfaces/trading_repository.py | order execution/placement | current | Classes: TradingRepository |
+| the_alchemiser/domain/interfaces/account_repository.py | utilities | current | Classes: AccountRepository |
+| the_alchemiser/domain/policies/policy_result.py | utilities | current | Classes: PolicyWarning, PolicyResult; Functions: create_approved_result, create_rejected_result |
+| the_alchemiser/domain/policies/base_policy.py | utilities | current | Classes: OrderPolicy |
+| the_alchemiser/domain/policies/risk_policy.py | utilities | current | Classes: RiskPolicy |
+| the_alchemiser/domain/policies/protocols.py | utilities | current | Classes: TradingClientProtocol, DataProviderProtocol |
+| the_alchemiser/domain/policies/buying_power_policy.py | utilities | current | Classes: BuyingPowerPolicy |
+| the_alchemiser/domain/policies/__init__.py | utilities | current |  |
+| the_alchemiser/domain/policies/fractionability_policy.py | utilities | current | Classes: FractionabilityPolicy |
+| the_alchemiser/domain/policies/position_policy.py | utilities | current | Classes: PositionPolicy |
+| the_alchemiser/domain/portfolio/__init__.py | portfolio assessment & management | current |  |
+| the_alchemiser/domain/strategies/typed_strategy_manager.py | strategy & signal generation | current | Classes: AggregatedSignals, TypedStrategyManager |
+| the_alchemiser/domain/strategies/nuclear_logic.py | utilities | current | Functions: evaluate_nuclear_strategy |
+| the_alchemiser/domain/strategies/__init__.py | utilities | current |  |
+| the_alchemiser/domain/strategies/typed_klm_ensemble_engine.py | utilities | current | Classes: TypedKLMStrategyEngine |
+| the_alchemiser/domain/strategies/tecl_strategy_engine.py | strategy & signal generation | current | Classes: TECLStrategyEngine; Functions: main |
+| the_alchemiser/domain/strategies/strategy_manager.py | strategy & signal generation | current |  |
+| the_alchemiser/domain/strategies/nuclear_typed_engine.py | utilities | current | Classes: NuclearTypedEngine |
+| the_alchemiser/domain/strategies/engine.py | utilities | current | Classes: StrategyEngine |
+| the_alchemiser/domain/services/__init__.py | utilities | current |  |
+| the_alchemiser/domain/services/rebalancing_policy.py | utilities | current | Functions: calculate_rebalance_orders |
+| the_alchemiser/domain/math/trading_math.py | order execution/placement | current | Functions: calculate_position_size, calculate_dynamic_limit_price, calculate_dynamic_limit_price_with_symbol, calculate_slippage_buffer, calculate_allocation_discrepancy, calculate_rebalance_amounts |
+| the_alchemiser/domain/math/__init__.py | utilities | current |  |
+| the_alchemiser/domain/math/indicator_utils.py | utilities | current | Functions: safe_get_indicator |
+| the_alchemiser/domain/math/asset_info.py | utilities | current | Classes: AssetType, FractionabilityDetector |
+| the_alchemiser/domain/math/math_utils.py | utilities | current | Functions: calculate_stdev_returns, calculate_moving_average, calculate_moving_average_return, calculate_percentage_change, calculate_rolling_metric, safe_division, normalize_to_range, calculate_ensemble_score |
+| the_alchemiser/domain/math/market_timing_utils.py | utilities | current | Classes: ExecutionStrategy, MarketOpenTimingEngine |
+| the_alchemiser/domain/math/indicators.py | utilities | current | Classes: TechnicalIndicators |
+| the_alchemiser/domain/models/strategy.py | strategy & signal generation | current | Classes: StrategySignalModel, StrategyPositionModel |
+| the_alchemiser/domain/models/__init__.py | utilities | current |  |
+| the_alchemiser/domain/models/market_data.py | utilities | current | Classes: BarModel, QuoteModel, PriceDataModel; Functions: bars_to_dataframe, dataframe_to_bars |
+| the_alchemiser/domain/models/position.py | utilities | current | Classes: PositionModel |
+| the_alchemiser/domain/models/account.py | utilities | current | Classes: AccountModel, PortfolioHistoryModel |
+| the_alchemiser/domain/models/order.py | order execution/placement | current | Classes: OrderModel |
+| the_alchemiser/domain/trading/lifecycle/exceptions.py | order execution/placement | current | Classes: InvalidOrderStateTransitionError |
+| the_alchemiser/domain/trading/lifecycle/protocols.py | order execution/placement | current | Classes: LifecycleObserver |
+| the_alchemiser/domain/trading/lifecycle/states.py | order execution/placement | current | Classes: OrderLifecycleState |
+| the_alchemiser/domain/trading/lifecycle/__init__.py | order execution/placement | current |  |
+| the_alchemiser/domain/trading/lifecycle/events.py | order execution/placement | current | Classes: LifecycleEventType, OrderLifecycleEvent |
+| the_alchemiser/domain/trading/lifecycle/transitions.py | order execution/placement | current |  |
+| the_alchemiser/domain/trading/protocols/order_lifecycle.py | order execution/placement | current | Classes: OrderLifecycleMonitor |
+| the_alchemiser/domain/trading/protocols/__init__.py | order execution/placement | current |  |
+| the_alchemiser/domain/trading/protocols/trading_repository.py | order execution/placement | current | Classes: TradingRepository |
+| the_alchemiser/domain/trading/value_objects/symbol.py | order execution/placement | current | Classes: Symbol |
+| the_alchemiser/domain/trading/value_objects/order_type.py | order execution/placement | current | Classes: OrderType |
+| the_alchemiser/domain/trading/value_objects/order_request.py | order execution/placement | current | Classes: OrderRequest |
+| the_alchemiser/domain/trading/value_objects/quantity.py | order execution/placement | current | Classes: Quantity |
+| the_alchemiser/domain/trading/value_objects/order_id.py | order execution/placement | current | Classes: OrderId |
+| the_alchemiser/domain/trading/value_objects/order_status.py | order execution/placement | current | Classes: OrderStatus |
+| the_alchemiser/domain/trading/value_objects/side.py | order execution/placement | current | Classes: Side |
+| the_alchemiser/domain/trading/value_objects/time_in_force.py | order execution/placement | current | Classes: TimeInForce |
+| the_alchemiser/domain/trading/value_objects/order_status_literal.py | order execution/placement | current |  |
+| the_alchemiser/domain/trading/errors/error_codes.py | order execution/placement | current | Classes: OrderErrorCode |
+| the_alchemiser/domain/trading/errors/classifier.py | order execution/placement | current | Classes: ClassificationRule, OrderErrorClassifier; Functions: classify_exception, classify_alpaca_error, classify_validation_failure |
+| the_alchemiser/domain/trading/errors/order_error.py | order execution/placement | current | Classes: OrderError; Functions: get_remediation_hint |
+| the_alchemiser/domain/trading/errors/__init__.py | order execution/placement | current |  |
+| the_alchemiser/domain/trading/errors/error_categories.py | order execution/placement | current | Classes: OrderErrorCategory |
+| the_alchemiser/domain/trading/entities/order.py | order execution/placement | current | Classes: Order |
+| the_alchemiser/domain/market_data/protocols/market_data_port.py | utilities | current | Classes: MarketDataPort |
+| the_alchemiser/domain/market_data/models/quote.py | utilities | current | Classes: QuoteModel |
+| the_alchemiser/domain/market_data/models/bar.py | utilities | current | Classes: BarModel |
+| the_alchemiser/domain/shared_kernel/value_objects/identifier.py | utilities | current | Classes: Identifier |
+| the_alchemiser/domain/shared_kernel/value_objects/symbol.py | utilities | current | Classes: Symbol |
+| the_alchemiser/domain/shared_kernel/value_objects/money.py | utilities | current | Classes: Money |
+| the_alchemiser/domain/shared_kernel/value_objects/percentage.py | utilities | current | Classes: Percentage |
+| the_alchemiser/domain/portfolio/strategy_attribution/symbol_classifier.py | strategy & signal generation | current | Classes: SymbolClassifier |
+| the_alchemiser/domain/portfolio/strategy_attribution/__init__.py | strategy & signal generation | current |  |
+| the_alchemiser/domain/portfolio/strategy_attribution/attribution_engine.py | strategy & signal generation | current | Classes: StrategyAttributionEngine |
+| the_alchemiser/domain/portfolio/position/position_analyzer.py | portfolio assessment & management | current | Classes: PositionAnalyzer |
+| the_alchemiser/domain/portfolio/position/position_delta.py | portfolio assessment & management | current | Classes: PositionDelta |
+| the_alchemiser/domain/portfolio/position/__init__.py | portfolio assessment & management | current |  |
+| the_alchemiser/domain/portfolio/rebalancing/rebalance_plan.py | portfolio assessment & management | current | Classes: RebalancePlan |
+| the_alchemiser/domain/portfolio/rebalancing/__init__.py | portfolio assessment & management | current |  |
+| the_alchemiser/domain/portfolio/rebalancing/rebalance_calculator.py | portfolio assessment & management | current | Classes: RebalanceCalculator |
+| the_alchemiser/domain/strategies/protocols/__init__.py | utilities | current |  |
+| the_alchemiser/domain/strategies/protocols/strategy_engine.py | strategy & signal generation | current | Classes: StrategyEngine |
+| the_alchemiser/domain/strategies/value_objects/alert.py | utilities | current | Classes: Alert |
+| the_alchemiser/domain/strategies/value_objects/strategy_signal.py | strategy & signal generation | current | Classes: StrategySignal |
+| the_alchemiser/domain/strategies/value_objects/confidence.py | utilities | current | Classes: Confidence |
+| the_alchemiser/domain/strategies/klm_workers/variant_506_38.py | utilities | current | Classes: KlmVariant50638 |
+| the_alchemiser/domain/strategies/klm_workers/variant_1200_28.py | utilities | current | Classes: KlmVariant120028 |
+| the_alchemiser/domain/strategies/klm_workers/variant_nova.py | utilities | current | Classes: KLMVariantNova |
+| the_alchemiser/domain/strategies/klm_workers/base_klm_variant.py | utilities | current | Classes: BaseKLMVariant |
+| the_alchemiser/domain/strategies/klm_workers/variant_520_22.py | utilities | current | Classes: KlmVariant52022 |
+| the_alchemiser/domain/strategies/klm_workers/__init__.py | utilities | current |  |
+| the_alchemiser/domain/strategies/klm_workers/variant_410_38.py | utilities | current | Classes: KlmVariant41038 |
+| the_alchemiser/domain/strategies/klm_workers/variant_530_18.py | utilities | current | Classes: KlmVariant53018 |
+| the_alchemiser/domain/strategies/klm_workers/variant_830_21.py | utilities | current | Classes: KlmVariant83021 |
+| the_alchemiser/domain/strategies/klm_workers/variant_1280_26.py | utilities | current | Classes: KlmVariant128026 |
+| the_alchemiser/domain/strategies/entities/__init__.py | utilities | current |  |
+| the_alchemiser/domain/strategies/models/strategy_position_model.py | strategy & signal generation | current | Classes: StrategyPositionModel |
+| the_alchemiser/domain/strategies/models/__init__.py | utilities | current |  |
+| the_alchemiser/domain/strategies/models/strategy_signal_model.py | strategy & signal generation | current | Classes: StrategySignalModel |
+| the_alchemiser/interfaces/schemas/cli.py | utilities | current | Classes: CLIOptions, CLICommandResult, CLISignalData, CLIAccountDisplay, CLIPortfolioData, CLIOrderDisplay |
+| the_alchemiser/interfaces/schemas/smart_trading.py | order execution/placement | current | Classes: OrderValidationMetadataDTO, SmartOrderExecutionDTO, TradingDashboardDTO |
+| the_alchemiser/interfaces/schemas/tracking.py | utilities | current | Classes: OrderEventStatus, ExecutionStatus, StrategyValidationMixin, StrategyOrderEventDTO, StrategyOrderDTO, StrategyPositionDTO, StrategyPnLDTO, StrategyExecutionSummaryDTO |
+| the_alchemiser/interfaces/schemas/execution.py | order execution/placement | current | Classes: TradingAction, WebSocketStatus, ExecutionResultDTO, TradingPlanDTO, WebSocketResultDTO, QuoteDTO, LambdaEventDTO, OrderHistoryDTO |
+| the_alchemiser/interfaces/schemas/reporting.py | utilities | current | Classes: DashboardMetrics, ReportingData, EmailReportData, EmailCredentials, EmailSummary, BacktestResult, PerformanceMetrics |
+| the_alchemiser/interfaces/schemas/__init__.py | utilities | current |  |
+| the_alchemiser/interfaces/schemas/execution_summary.py | order execution/placement | current | Classes: AllocationSummaryDTO, StrategyPnLSummaryDTO, StrategySummaryDTO, TradingSummaryDTO, ExecutionSummaryDTO, PortfolioStateDTO |
+| the_alchemiser/interfaces/schemas/enriched_data.py | utilities | current | Classes: EnrichedOrderDTO, OpenOrdersDTO, EnrichedPositionDTO, EnrichedPositionsDTO |
+| the_alchemiser/interfaces/schemas/orders.py | order execution/placement | current | Classes: OrderValidationMixin, OrderRequestDTO, ValidatedOrderDTO, OrderExecutionResultDTO, LimitOrderResultDTO, RawOrderEnvelope, AdjustedOrderRequestDTO, PolicyWarningDTO |
+| the_alchemiser/interfaces/schemas/market_data.py | utilities | current | Classes: PriceDTO, PriceHistoryDTO, SpreadAnalysisDTO, MarketStatusDTO, MultiSymbolQuotesDTO |
+| the_alchemiser/interfaces/schemas/base.py | utilities | current | Classes: ResultDTO |
+| the_alchemiser/interfaces/schemas/common.py | utilities | current | Classes: MultiStrategyExecutionResultDTO |
+| the_alchemiser/interfaces/schemas/portfolio_rebalancing.py | portfolio assessment & management | current | Classes: RebalancePlanDTO, RebalancePlanCollectionDTO, RebalancingSummaryDTO, RebalancingImpactDTO, RebalanceInstructionDTO, RebalanceExecutionResultDTO |
+| the_alchemiser/interfaces/schemas/alpaca.py | utilities | current | Classes: AlpacaOrderDTO, AlpacaErrorDTO |
+| the_alchemiser/interfaces/schemas/accounts.py | utilities | current | Classes: AccountSummaryDTO, AccountMetricsDTO, BuyingPowerDTO, RiskMetricsDTO, TradeEligibilityDTO, PortfolioAllocationDTO, EnrichedAccountSummaryDTO |
+| the_alchemiser/interfaces/schemas/operations.py | utilities | current | Classes: OperationResultDTO, OrderCancellationDTO, OrderStatusDTO |
+| the_alchemiser/interfaces/schemas/errors.py | utilities | current | Classes: ErrorDetailInfo, ErrorSummaryData, ErrorReportSummary, ErrorNotificationData, ErrorContextData |
+| the_alchemiser/interfaces/schemas/positions.py | utilities | current | Classes: PositionDTO, PositionSummaryDTO, PortfolioSummaryDTO, PortfolioMetricsDTO, PositionAnalyticsDTO, PositionMetricsDTO, LargestPositionDTO, ClosePositionResultDTO, PortfolioValueDTO |
+| the_alchemiser/services/repository/alpaca_manager.py | utilities | current | Classes: AlpacaManager; Functions: create_alpaca_manager |
+| the_alchemiser/services/repository/__init__.py | utilities | current |  |
+| the_alchemiser/services/trading/position_manager.py | order execution/placement | current | Classes: PositionManager |
+| the_alchemiser/services/trading/trading_client_service.py | order execution/placement | current | Classes: TradingClientService |
+| the_alchemiser/services/trading/__init__.py | order execution/placement | current |  |
+| the_alchemiser/services/trading/order_service.py | order execution/placement | current | Classes: OrderType, OrderValidationError, OrderOperationError, OrderService |
+| the_alchemiser/services/trading/position_service.py | order execution/placement | current | Classes: PositionInfo, PortfolioSummary, PositionValidationError, PositionService |
+| the_alchemiser/services/trading/trading_service_manager.py | order execution/placement | current | Classes: TradingServiceManager |
+| the_alchemiser/services/market_data/streaming_service.py | utilities | current | Classes: _RealTimePricingProtocol, StreamingService |
+| the_alchemiser/services/market_data/price_utils.py | utilities | current | Functions: ensure_scalar_price |
+| the_alchemiser/services/market_data/__init__.py | utilities | current |  |
+| the_alchemiser/services/market_data/market_data_client.py | utilities | current | Classes: MarketDataClient |
+| the_alchemiser/services/market_data/strategy_market_data_service.py | strategy & signal generation | current | Classes: StrategyMarketDataService |
+| the_alchemiser/services/market_data/price_fetching_utils.py | utilities | current | Functions: subscribe_for_real_time, extract_bid_ask, calculate_price_from_bid_ask, get_price_from_quote_api, get_price_from_historical_fallback, create_cleanup_function |
+| the_alchemiser/services/market_data/market_data_service.py | utilities | current | Classes: MarketDataService |
+| the_alchemiser/services/market_data/price_service.py | utilities | current | Classes: ModernPriceFetchingService |
+| the_alchemiser/services/errors/handler.py | utilities | current | Classes: ErrorSeverity, ErrorCategory, ErrorDetails, EnhancedAlchemiserError, TradingSystemErrorHandler, EnhancedTradingError, EnhancedDataError, CircuitBreakerOpenError, CircuitBreaker, EnhancedErrorReporter; Functions: get_error_handler, handle_trading_error, send_error_notification_if_needed, retry_with_backoff, categorize_error_severity, create_enhanced_error, get_enhanced_error_reporter, get_global_error_reporter, handle_errors_with_retry |
+| the_alchemiser/services/errors/error_recovery.py | utilities | current | Classes: RecoveryResult, ErrorRecoveryStrategy, TradingErrorRecovery, DataErrorRecovery, CircuitState, CircuitBreakerOpenError, CircuitBreaker, RetryStrategy, ExponentialBackoffStrategy, LinearBackoffStrategy, FixedIntervalStrategy, FibonacciBackoffStrategy, SmartRetryManager, ErrorRecoveryManager; Functions: get_recovery_manager, with_circuit_breaker, with_retry, with_resilience |
+| the_alchemiser/services/errors/exceptions.py | utilities | current | Classes: AlchemiserError, ConfigurationError, DataProviderError, TradingClientError, OrderExecutionError, OrderPlacementError, OrderTimeoutError, SpreadAnalysisError, BuyingPowerError, InsufficientFundsError, PositionValidationError, StrategyExecutionError, IndicatorCalculationError, MarketDataError, ValidationError, NotificationError, S3OperationError, RateLimitError, MarketClosedError, WebSocketError, StreamingError, LoggingError, FileOperationError, DatabaseError, SecurityError, EnvironmentError |
+| the_alchemiser/services/errors/error_reporter.py | utilities | current | Classes: ErrorReporter; Functions: get_error_reporter, report_error_globally |
+| the_alchemiser/services/errors/error_handling.py | utilities | current | Classes: ErrorHandler, ServiceMetrics, ErrorContext; Functions: create_service_logger, _deprecated_decorator_stub, _deprecated_instance_stub, with_metrics |
+| the_alchemiser/services/errors/__init__.py | utilities | current |  |
+| the_alchemiser/services/errors/decorators.py | utilities | current | Functions: translate_service_errors, translate_market_data_errors, translate_trading_errors, translate_streaming_errors, translate_config_errors |
+| the_alchemiser/services/errors/scope.py | utilities | current | Classes: _ScopeErrorHandler, ErrorScope; Functions: create_error_scope |
+| the_alchemiser/services/errors/context.py | utilities | current | Classes: ErrorContextData; Functions: create_error_context |
+| the_alchemiser/services/errors/error_monitoring.py | utilities | current | Classes: HealthStatus, ErrorEvent, RecoveryStats, ErrorMetricsCollector, AlertThresholdManager, HealthReport, ErrorHealthDashboard, ProductionMonitor; Functions: get_production_monitor, record_error_for_monitoring, record_recovery_for_monitoring, get_system_health, get_health_dashboard |
+| the_alchemiser/services/account/account_utils.py | utilities | current | Functions: extract_comprehensive_account_data, extract_basic_account_metrics, calculate_position_target_deltas, extract_current_position_values |
+| the_alchemiser/services/account/__init__.py | utilities | current |  |
+| the_alchemiser/services/account/account_service.py | utilities | current | Classes: AccountService |
+| the_alchemiser/services/shared/config_service.py | utilities | current | Classes: ConfigService |
+| the_alchemiser/services/shared/service_factory.py | utilities | current | Classes: ServiceFactory |
+| the_alchemiser/services/shared/__init__.py | utilities | current |  |
+| the_alchemiser/services/shared/retry_decorator.py | utilities | current | Functions: retry_with_backoff, retry_api_call, retry_data_fetch, retry_order_execution |
+| the_alchemiser/services/shared/cache_manager.py | utilities | current | Classes: CacheManager |
+| the_alchemiser/services/shared/secrets_service.py | utilities | current | Classes: SecretsService |
+| the_alchemiser/interface/cli/signal_analyzer.py | utilities | current | Classes: SignalAnalyzer |
+| the_alchemiser/interface/cli/cli.py | utilities | current | Functions: show_welcome, signal, trade, status, dsl_count, deploy, version, validate_indicators, main |
+| the_alchemiser/interface/cli/signal_display_utils.py | utilities | current | Functions: display_signal_results, display_typed_signal_results, display_signal_results_unified, display_technical_indicators, display_portfolio_details |
+| the_alchemiser/interface/cli/__init__.py | utilities | current |  |
+| the_alchemiser/interface/cli/cli_formatter.py | utilities | current | Functions: render_technical_indicators, render_strategy_signals, render_portfolio_allocation, render_orders_executed, _format_money, render_account_info, render_header, render_footer, render_target_vs_current_allocations, render_execution_plan, render_enriched_order_summaries, render_multi_strategy_summary |
+| the_alchemiser/interface/cli/trading_executor.py | order execution/placement | current | Classes: TradingExecutor |
+| the_alchemiser/interface/cli/portfolio_calculations.py | portfolio assessment & management | current | Functions: calculate_target_vs_current_allocations |
+| the_alchemiser/interface/cli/error_display_utils.py | utilities | current | Functions: render_order_error, render_order_errors_table, render_error_summary, format_error_for_notification, _get_error_severity |
+| the_alchemiser/interface/cli/dashboard_utils.py | utilities | current | Functions: build_basic_dashboard_structure, extract_portfolio_metrics, extract_positions_data, extract_strategies_data, extract_recent_trades_data, build_s3_paths |
+| the_alchemiser/interface/email/client.py | utilities | current | Classes: EmailClient; Functions: send_email_notification |
+| the_alchemiser/interface/email/email_utils.py | utilities | current | Functions: _build_portfolio_display, _build_closed_positions_pnl_email_html, _build_technical_indicators_email_html, _build_detailed_strategy_signals_email_html, _build_enhanced_trading_summary_email_html, _build_enhanced_portfolio_email_html |
+| the_alchemiser/interface/email/__init__.py | utilities | current |  |
+| the_alchemiser/interface/email/config.py | utilities | current | Classes: EmailConfig; Functions: get_email_config, is_neutral_mode_enabled |
+| the_alchemiser/interface/email/templates/performance.py | utilities | current | Classes: PerformanceBuilder |
+| the_alchemiser/interface/email/templates/multi_strategy.py | strategy & signal generation | current | Classes: MultiStrategyReportBuilder |
+| the_alchemiser/interface/email/templates/__init__.py | utilities | current | Classes: EmailTemplates; Functions: build_trading_report_html, build_multi_strategy_email_html, build_multi_strategy_email_html_neutral, build_error_email_html |
+| the_alchemiser/interface/email/templates/base.py | utilities | current | Classes: BaseEmailTemplate |
+| the_alchemiser/interface/email/templates/trading_report.py | order execution/placement | current | Classes: TradingReportBuilder |
+| the_alchemiser/interface/email/templates/error_report.py | utilities | current | Classes: ErrorReportBuilder |
+| the_alchemiser/interface/email/templates/portfolio.py | portfolio assessment & management | current | Classes: ExecutionSummaryLike, PortfolioBuilder; Functions: _normalise_result |
+| the_alchemiser/interface/email/templates/signals.py | utilities | current | Classes: SignalsBuilder |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ source .venv/bin/activate
 export PYTHONPATH="${PWD}:${PWD}/the_alchemiser:${PYTHONPATH}"
 ```
 
+## Business Unit Classification
+
+Every source file begins with a module-level docstring that declares:
+
+- **Business Unit** – one of
+  - strategy & signal generation
+  - portfolio assessment & management
+  - order execution/placement
+  - utilities
+- **Status** – `current` or `legacy`
+
+See `BUSINESS_UNITS_REPORT.md` for the complete, auto-generated inventory.
+Contributors must keep these docstrings accurate when files are created or
+significantly changed.
+
 ## System Architecture
 
 ### Layered DDD Architecture (Domain-Driven Design)

--- a/examples/policy_layer_usage.py
+++ b/examples/policy_layer_usage.py
@@ -1,4 +1,6 @@
-"""Unified Policy Layer Usage Example
+"""Business Unit: utilities; Status: legacy.
+
+Unified Policy Layer Usage Example
 
 This example demonstrates how to use the new unified policy layer
 for order validation and adjustment.

--- a/scripts/update_docstrings.py
+++ b/scripts/update_docstrings.py
@@ -1,0 +1,85 @@
+"""Business Unit: utilities; Status: current.
+"""
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path('.').resolve()
+PY_FILES = [p for p in ROOT.rglob('*.py') if '.venv' not in p.parts]
+
+
+def classify(path: str) -> str:
+    l = path.lower()
+    if 'strategy' in l:
+        return 'strategy & signal generation'
+    if 'portfolio' in l:
+        return 'portfolio assessment & management'
+    if any(t in l for t in ['trading', 'order', 'execution']):
+        return 'order execution/placement'
+    return 'utilities'
+
+
+def status(path: str) -> str:
+    l = path.lower()
+    if any(t in l for t in ['example', 'legacy', 'deprecated']):
+        return 'legacy'
+    return 'current'
+
+
+report = []
+
+for p in PY_FILES:
+    rel = str(p.relative_to(ROOT))
+    bu = classify(rel)
+    st = status(rel)
+    src = p.read_text(encoding='utf-8')
+    try:
+        mod = ast.parse(src)
+        classes = [n.name for n in mod.body if isinstance(n, ast.ClassDef)]
+        funcs = [n.name for n in mod.body if isinstance(n, ast.FunctionDef)]
+        existing_doc = ast.get_docstring(mod, clean=False) or ''
+    except SyntaxError:
+        classes, funcs, existing_doc = [], [], ''
+
+    desc_parts = []
+    if classes:
+        desc_parts.append('Classes: ' + ', '.join(classes))
+    if funcs:
+        desc_parts.append('Functions: ' + ', '.join(funcs))
+    desc = '; '.join(desc_parts)
+
+    lines = src.splitlines()
+    insert_idx = 0
+    while insert_idx < len(lines) and lines[insert_idx].startswith('#'):
+        insert_idx += 1
+    start_idx = insert_idx
+    end_idx = insert_idx
+    if insert_idx < len(lines) and lines[insert_idx].startswith(('"""', "'''")):
+        quote = '"""' if lines[insert_idx].startswith('"""') else "'''"
+        first_line = lines[insert_idx]
+        if first_line.strip().endswith(quote) and first_line.count(quote) >= 2:
+            end_idx = insert_idx + 1
+        else:
+            j = insert_idx + 1
+            while j < len(lines) and not lines[j].endswith(quote):
+                j += 1
+            if j < len(lines):
+                end_idx = j + 1
+        lines = lines[:start_idx] + lines[end_idx:]
+    doc_lines = [f'Business Unit: {bu}; Status: {st}.']
+    if existing_doc.strip():
+        doc_lines.append('')
+        doc_lines.extend(existing_doc.strip().splitlines())
+    docstring = '"""' + "\n".join(doc_lines) + '\n"""'
+    lines = lines[:start_idx] + [docstring] + lines[start_idx:]
+    p.write_text("\n".join(lines) + "\n", encoding='utf-8')
+
+    report.append({'file': rel, 'business_unit': bu, 'status': st, 'description': desc})
+
+Path('BUSINESS_UNITS_REPORT.json').write_text(json.dumps(report, indent=2), encoding='utf-8')
+
+md_lines = ["# Business Units Report", "", "| File | Business Unit | Status | Description |", "| --- | --- | --- | --- |"]
+for r in report:
+    md_lines.append(f"| {r['file']} | {r['business_unit']} | {r['status']} | {r['description']} |")
+Path('BUSINESS_UNITS_REPORT.md').write_text("\n".join(md_lines) + "\n", encoding='utf-8')
+print(f'Processed {len(report)} files')

--- a/the_alchemiser/__init__.py
+++ b/the_alchemiser/__init__.py
@@ -1,4 +1,6 @@
-"""The Alchemiser Quantitative Trading System Package.
+"""Business Unit: utilities; Status: current.
+
+The Alchemiser Quantitative Trading System Package.
 
 A sophisticated multi-strategy quantitative trading system for automated portfolio management using
 algorithmic trading strategies. The package supports multiple trading strategies,
@@ -28,5 +30,4 @@ Example:
 
 Author: Josh Moreton
 License: Private
-
 """

--- a/the_alchemiser/application/__init__.py
+++ b/the_alchemiser/application/__init__.py
@@ -1,4 +1,6 @@
-"""Execution package for The Alchemiser Quantitative Trading System.
+"""Business Unit: utilities; Status: current.
+
+Execution package for The Alchemiser Quantitative Trading System.
 
 This package handles the execution layer of the trading system, including
 order management, portfolio rebalancing, and trade execution. It provides

--- a/the_alchemiser/application/execution/__init__.py
+++ b/the_alchemiser/application/execution/__init__.py
@@ -1,4 +1,6 @@
-"""Execution layer for order execution and market interaction.
+"""Business Unit: order execution/placement; Status: current.
+
+Execution layer for order execution and market interaction.
 
 This module contains the smart execution engine and related utilities for handling
 sophisticated order placement strategies, market timing, and execution optimization.

--- a/the_alchemiser/application/execution/canonical_executor.py
+++ b/the_alchemiser/application/execution/canonical_executor.py
@@ -1,4 +1,6 @@
-"""Canonical Order Executor (Phase 3 - Unified Policy Layer).
+"""Business Unit: order execution/placement; Status: current.
+
+Canonical Order Executor (Phase 3 - Unified Policy Layer).
 
 Enhanced implementation with policy orchestrator integration:
 * Integrates PolicyOrchestrator for unified pre-placement validation

--- a/the_alchemiser/application/execution/canonical_integration_example.py
+++ b/the_alchemiser/application/execution/canonical_integration_example.py
@@ -1,4 +1,6 @@
-"""Integration example for canonical order executor.
+"""Business Unit: order execution/placement; Status: legacy.
+
+Integration example for canonical order executor.
 
 This module demonstrates how the canonical order executor can be integrated
 into existing trading workflows with shadow mode for safe rollout.

--- a/the_alchemiser/application/execution/execution_manager.py
+++ b/the_alchemiser/application/execution/execution_manager.py
@@ -1,4 +1,7 @@
-"""Coordinate execution of multiple trading strategies."""
+"""Business Unit: order execution/placement; Status: current.
+
+Coordinate execution of multiple trading strategies.
+"""
 
 import logging
 from typing import Any

--- a/the_alchemiser/application/execution/order_lifecycle_adapter.py
+++ b/the_alchemiser/application/execution/order_lifecycle_adapter.py
@@ -1,4 +1,6 @@
-"""Adapter bridging infrastructure websocket monitor to OrderLifecycleMonitor Protocol.
+"""Business Unit: order execution/placement; Status: current.
+
+Adapter bridging infrastructure websocket monitor to OrderLifecycleMonitor Protocol.
 
 Keeps application layer decoupled from infrastructure implementation while
 reusing the existing OrderCompletionMonitor without private attribute access.

--- a/the_alchemiser/application/execution/order_request_builder.py
+++ b/the_alchemiser/application/execution/order_request_builder.py
@@ -1,4 +1,6 @@
-"""Centralized order request builder for Alpaca API requests.
+"""Business Unit: order execution/placement; Status: current.
+
+Centralized order request builder for Alpaca API requests.
 
 This module provides a single construction site for MarketOrderRequest and
 LimitOrderRequest objects, eliminating duplication across services and

--- a/the_alchemiser/application/execution/smart_execution.py
+++ b/the_alchemiser/application/execution/smart_execution.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Smart Execution Engine with Professional Order Strategy.
+"""Business Unit: order execution/placement; Status: current.
+
+Smart Execution Engine with Professional Order Strategy.
 
 This module provides sophisticated order execution using the Better Orders strategy:
 - Aggressive marketable limits (ask+1¢ for buys, bid-            # Get alpaca manager from order executor for canonical executor

--- a/the_alchemiser/application/execution/smart_pricing_handler.py
+++ b/the_alchemiser/application/execution/smart_pricing_handler.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Smart Pricing Handler.
+"""Business Unit: order execution/placement; Status: current.
+
+Smart Pricing Handler.
 
 This module provides intelligent pricing strategies based on market conditions,
 bid/ask spreads, and order aggressiveness settings.

--- a/the_alchemiser/application/execution/spread_assessment.py
+++ b/the_alchemiser/application/execution/spread_assessment.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Spread Assessment for Better Order Execution.
+"""Business Unit: order execution/placement; Status: current.
+
+Spread Assessment for Better Order Execution.
 
 Implements pre-market and real-time spread analysis to optimize
 order timing and pricing decisions.

--- a/the_alchemiser/application/execution/strategies/__init__.py
+++ b/the_alchemiser/application/execution/strategies/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Execution strategies package.
+"""Business Unit: order execution/placement; Status: current.
+
+Execution strategies package.
 
 Contains strategy classes for order execution patterns including
 repeg strategies and aggressive limit strategies.

--- a/the_alchemiser/application/execution/strategies/aggressive_limit_strategy.py
+++ b/the_alchemiser/application/execution/strategies/aggressive_limit_strategy.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Aggressive Limit Strategy.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Aggressive Limit Strategy.
 
 Orchestrates RepegStrategy until order is filled or all attempts are exhausted.
 Handles order lifecycle, error management, and execution flow.

--- a/the_alchemiser/application/execution/strategies/config.py
+++ b/the_alchemiser/application/execution/strategies/config.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Strategy Configuration DTO.
+"""Business Unit: order execution/placement; Status: current.
+
+Strategy Configuration DTO.
 
 Defines configuration parameters for execution strategies including
 repeg attempts, timeouts, volatility thresholds, and pricing ticks.

--- a/the_alchemiser/application/execution/strategies/execution_context_adapter.py
+++ b/the_alchemiser/application/execution/strategies/execution_context_adapter.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Execution Context Adapter.
+"""Business Unit: order execution/placement; Status: current.
+
+Execution Context Adapter.
 
 Adapter to bridge OrderExecutor protocol to ExecutionContext protocol
 for strategy compatibility using canonical executor.

--- a/the_alchemiser/application/execution/strategies/repeg_strategy.py
+++ b/the_alchemiser/application/execution/strategies/repeg_strategy.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Repeg Strategy.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Repeg Strategy.
 
 Stateless strategy for planning and executing re-pegging attempts with
 adaptive pricing and timeout logic.

--- a/the_alchemiser/application/mapping/__init__.py
+++ b/the_alchemiser/application/mapping/__init__.py
@@ -1,4 +1,6 @@
-"""Mapping layer: DTO <-> Domain conversion utilities.
+"""Business Unit: utilities; Status: current.
+
+Mapping layer: DTO <-> Domain conversion utilities.
 
 All modules here provide pure functions for translating between external DTOs, domain
 value objects/entities and infrastructure payloads. Import specific functions rather

--- a/the_alchemiser/application/mapping/account_mapping.py
+++ b/the_alchemiser/application/mapping/account_mapping.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/application/mapping/alpaca_dto_mapping.py
+++ b/the_alchemiser/application/mapping/alpaca_dto_mapping.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Alpaca DTO mapping utilities for infrastructure boundary.
+"""Business Unit: utilities; Status: current.
+
+Alpaca DTO mapping utilities for infrastructure boundary.
 
 This module provides mapping functions to convert between Alpaca API responses
 and OrderExecutionResultDTO, ensuring proper type conversion and validation

--- a/the_alchemiser/application/mapping/execution.py
+++ b/the_alchemiser/application/mapping/execution.py
@@ -1,4 +1,6 @@
-"""Execution mapping utilities (anti-corruption layer).
+"""Business Unit: order execution/placement; Status: current.
+
+Execution mapping utilities (anti-corruption layer).
 
 Ordered fixes applied (review issues 1→10):
 1. DDD boundary alignment: introduce internal normalisation for order objects so

--- a/the_alchemiser/application/mapping/execution_summary_mapping.py
+++ b/the_alchemiser/application/mapping/execution_summary_mapping.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Mapping functions for execution summary DTOs.
+"""Business Unit: order execution/placement; Status: current.
+
+Mapping functions for execution summary DTOs.
 
 This module provides mapping utilities to convert between dict structures
 and ExecutionSummaryDTO/PortfolioStateDTO, supporting the migration from

--- a/the_alchemiser/application/mapping/market_data_mappers.py
+++ b/the_alchemiser/application/mapping/market_data_mappers.py
@@ -1,4 +1,7 @@
-"""Mapping utilities between infra/DTOs and domain market data models."""
+"""Business Unit: utilities; Status: current.
+
+Mapping utilities between infra/DTOs and domain market data models.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/application/mapping/market_data_mapping.py
+++ b/the_alchemiser/application/mapping/market_data_mapping.py
@@ -1,4 +1,6 @@
-"""Market data mapping utilities for strategy adaptation.
+"""Business Unit: utilities; Status: current.
+
+Market data mapping utilities for strategy adaptation.
 
 Provides conversion functions between typed domain models and DataFrame formats
 for strategies that still need pandas ergonomics while maintaining domain purity.

--- a/the_alchemiser/application/mapping/order_mapping.py
+++ b/the_alchemiser/application/mapping/order_mapping.py
@@ -1,4 +1,6 @@
-"""Mapping utilities between Alpaca order objects and domain Order entity.
+"""Business Unit: order execution/placement; Status: current.
+
+Mapping utilities between Alpaca order objects and domain Order entity.
 
 This module is part of the anti-corruption layer. It converts external Alpaca
 order representations into pure domain models so the rest of the application

--- a/the_alchemiser/application/mapping/orders.py
+++ b/the_alchemiser/application/mapping/orders.py
@@ -1,4 +1,7 @@
-"""Order mapping utilities and status normalization (application layer)."""
+"""Business Unit: order execution/placement; Status: current.
+
+Order mapping utilities and status normalization (application layer).
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/application/mapping/pandas_time_series.py
+++ b/the_alchemiser/application/mapping/pandas_time_series.py
@@ -1,4 +1,7 @@
-"""Utilities to convert domain time-series models to pandas structures for indicators."""
+"""Business Unit: utilities; Status: current.
+
+Utilities to convert domain time-series models to pandas structures for indicators.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/application/mapping/policy_mapping.py
+++ b/the_alchemiser/application/mapping/policy_mapping.py
@@ -1,4 +1,6 @@
-"""Policy mapping utilities for converting between DTOs and domain objects.
+"""Business Unit: utilities; Status: current.
+
+Policy mapping utilities for converting between DTOs and domain objects.
 
 This module is part of the anti-corruption layer, converting between interface
 DTOs (Pydantic models) and pure domain objects for policy processing. This

--- a/the_alchemiser/application/mapping/portfolio_rebalancing_mapping.py
+++ b/the_alchemiser/application/mapping/portfolio_rebalancing_mapping.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Mapping functions for portfolio rebalancing DTOs.
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Mapping functions for portfolio rebalancing DTOs.
 
 This module provides mapping utilities to convert between dict structures,
 domain objects, and portfolio rebalancing DTOs, supporting the migration from

--- a/the_alchemiser/application/mapping/position_mapping.py
+++ b/the_alchemiser/application/mapping/position_mapping.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/application/mapping/strategies.py
+++ b/the_alchemiser/application/mapping/strategies.py
@@ -1,4 +1,6 @@
-"""Pure mapping functions for strategy signals to display/DTO dictionaries.
+"""Business Unit: utilities; Status: current.
+
+Pure mapping functions for strategy signals to display/DTO dictionaries.
 
 This module consolidates strategy signal mapping in a dedicated mapping module and
 removes ad-hoc dict shapes from runtime paths. It provides pure mapping

--- a/the_alchemiser/application/mapping/strategy_domain_mapping.py
+++ b/the_alchemiser/application/mapping/strategy_domain_mapping.py
@@ -1,4 +1,6 @@
-"""Mapping utilities between strategy DTOs and domain objects.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Mapping utilities between strategy DTOs and domain objects.
 
 This module provides conversion functions between TypedDict DTOs (used at interface
 boundaries) and domain value objects/models (used in business logic).

--- a/the_alchemiser/application/mapping/strategy_market_data_adapter.py
+++ b/the_alchemiser/application/mapping/strategy_market_data_adapter.py
@@ -1,4 +1,6 @@
-"""Strategy market data adapter for DataFrame compatibility.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy market data adapter for DataFrame compatibility.
 
 This adapter bridges strategies that expect DataFrame-based MarketDataPort
 to use the canonical domain-based MarketDataPort with Symbol and domain models.

--- a/the_alchemiser/application/mapping/strategy_signal_mapping.py
+++ b/the_alchemiser/application/mapping/strategy_signal_mapping.py
@@ -1,4 +1,6 @@
-"""Mapping utilities for strategy signals to typed domain structures.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Mapping utilities for strategy signals to typed domain structures.
 
 This module provides bidirectional conversion between strategy signals:
 1. Legacy dicts → typed domain StrategySignal (legacy_signal_to_typed)

--- a/the_alchemiser/application/mapping/tracking.py
+++ b/the_alchemiser/application/mapping/tracking.py
@@ -1,4 +1,6 @@
-"""Mapping utilities between Strategy Tracking DTOs and external reporting formats.
+"""Business Unit: utilities; Status: current.
+
+Mapping utilities between Strategy Tracking DTOs and external reporting formats.
 
 This module provides mapping functions for strategy tracking DTOs, converting
 between StrategyOrderEventDTO/StrategyExecutionSummaryDTO and external reporting

--- a/the_alchemiser/application/mapping/tracking_mapping.py
+++ b/the_alchemiser/application/mapping/tracking_mapping.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Mapping utilities between tracking DTOs and internal dataclasses.
+"""Business Unit: utilities; Status: current.
+
+Mapping utilities between tracking DTOs and internal dataclasses.
 
 This module provides anti-corruption layer mappings for the strategy_order_tracker
 refactor, converting between StrategyOrderEventDTO/StrategyExecutionSummaryDTO

--- a/the_alchemiser/application/mapping/tracking_normalization.py
+++ b/the_alchemiser/application/mapping/tracking_normalization.py
@@ -1,4 +1,6 @@
-"""Tracking data normalization utilities.
+"""Business Unit: utilities; Status: current.
+
+Tracking data normalization utilities.
 
 Centralized quantization and normalization for strategy tracking data to ensure
 consistent precision handling and avoid float comparison issues.

--- a/the_alchemiser/application/mapping/trading_service_dto_mapping.py
+++ b/the_alchemiser/application/mapping/trading_service_dto_mapping.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""DTO mapping utilities for TradingServiceManager results.
+"""Business Unit: order execution/placement; Status: current.
+
+DTO mapping utilities for TradingServiceManager results.
 
 This module provides mapping functions to convert between internal data structures
 and DTOs for the TradingServiceManager facade, ensuring type-safe returns.

--- a/the_alchemiser/application/orders/__init__.py
+++ b/the_alchemiser/application/orders/__init__.py
@@ -1,4 +1,6 @@
-"""Order management and handling layer.
+"""Business Unit: order execution/placement; Status: current.
+
+Order management and handling layer.
 
 This module contains all order-related functionality including validation,
 progressive orders, limit orders, and asset-specific order handling.

--- a/the_alchemiser/application/orders/asset_order_handler.py
+++ b/the_alchemiser/application/orders/asset_order_handler.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Asset-Specific Order Logic.
+"""Business Unit: order execution/placement; Status: current.
+
+Asset-Specific Order Logic.
 
 This module handles asset-specific order placement logic, including
 fractionable vs non-fractionable asset handling, order type conversion,

--- a/the_alchemiser/application/orders/order_validation.py
+++ b/the_alchemiser/application/orders/order_validation.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Order Validation and Type Safety Module.
+"""Business Unit: order execution/placement; Status: current.
+
+Order Validation and Type Safety Module.
 
 This module provides comprehensive order validation and type safety for trade execution.
 It uses strongly typed DTOs from interfaces/schemas/orders.py and integrates with the

--- a/the_alchemiser/application/orders/order_validation_utils.py
+++ b/the_alchemiser/application/orders/order_validation_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Order Validation Utilities.
+"""Business Unit: order execution/placement; Status: current.
+
+Order Validation Utilities.
 
 This module provides helper functions for validating order parameters,
 including quantity validation, price validation, and parameter normalization.

--- a/the_alchemiser/application/orders/progressive_order_utils.py
+++ b/the_alchemiser/application/orders/progressive_order_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Progressive Order Execution Utilities.
+"""Business Unit: order execution/placement; Status: current.
+
+Progressive Order Execution Utilities.
 
 This module provides intelligent order execution parameters based on market conditions:
 - Volatility-aware timeout adjustments

--- a/the_alchemiser/application/policies/__init__.py
+++ b/the_alchemiser/application/policies/__init__.py
@@ -1,4 +1,6 @@
-"""Concrete Policy Implementations
+"""Business Unit: utilities; Status: current.
+
+Concrete Policy Implementations
 
 This module provides concrete implementations of the domain policy interfaces.
 These implementations contain the actual business logic for order validation

--- a/the_alchemiser/application/policies/buying_power_policy_impl.py
+++ b/the_alchemiser/application/policies/buying_power_policy_impl.py
@@ -1,4 +1,6 @@
-"""Buying Power Policy Implementation
+"""Business Unit: utilities; Status: current.
+
+Buying Power Policy Implementation
 
 Concrete implementation of BuyingPowerPolicy that handles buying power validation.
 Extracts logic from PositionManager and ensures BuyingPowerError is raised properly.

--- a/the_alchemiser/application/policies/fractionability_policy_impl.py
+++ b/the_alchemiser/application/policies/fractionability_policy_impl.py
@@ -1,4 +1,6 @@
-"""Fractionability policy implementation.
+"""Business Unit: utilities; Status: current.
+
+Fractionability policy implementation.
 
 Concrete implementation handling asset fractionability validation and quantity
 adjustments (extracted from legacy handlers) using pure domain objects.

--- a/the_alchemiser/application/policies/policy_factory.py
+++ b/the_alchemiser/application/policies/policy_factory.py
@@ -1,4 +1,6 @@
-"""Policy Factory
+"""Business Unit: utilities; Status: current.
+
+Policy Factory
 
 Factory for creating policy orchestrator with all required dependencies.
 Provides convenient methods for setting up the policy layer.

--- a/the_alchemiser/application/policies/policy_orchestrator.py
+++ b/the_alchemiser/application/policies/policy_orchestrator.py
@@ -1,4 +1,6 @@
-"""Policy Orchestrator
+"""Business Unit: utilities; Status: current.
+
+Policy Orchestrator
 
 Central coordinator for all order validation policies. Runs policies in sequence
 and aggregates their results into a final order decision. Now uses pure domain

--- a/the_alchemiser/application/policies/position_policy_impl.py
+++ b/the_alchemiser/application/policies/position_policy_impl.py
@@ -1,4 +1,6 @@
-"""Position Policy Implementation
+"""Business Unit: utilities; Status: current.
+
+Position Policy Implementation
 
 Concrete implementation of PositionPolicy that handles position validation
 and quantity adjustments. Extracts logic from PositionManager.

--- a/the_alchemiser/application/policies/risk_policy_impl.py
+++ b/the_alchemiser/application/policies/risk_policy_impl.py
@@ -1,4 +1,6 @@
-"""Risk Policy Implementation
+"""Business Unit: utilities; Status: current.
+
+Risk Policy Implementation
 
 Concrete implementation of RiskPolicy that handles risk assessment and limits.
 Now uses pure domain objects and typed protocols.

--- a/the_alchemiser/application/portfolio/__init__.py
+++ b/the_alchemiser/application/portfolio/__init__.py
@@ -1,1 +1,4 @@
-"""Portfolio application services."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio application services.
+"""

--- a/the_alchemiser/application/portfolio/portfolio_pnl_utils.py
+++ b/the_alchemiser/application/portfolio/portfolio_pnl_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Portfolio P&L Utilities.
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio P&L Utilities.
 
 This module provides helper functions for calculating and extracting
 profit and loss data from strategy tracking and portfolio positions.

--- a/the_alchemiser/application/portfolio/rebalancing_orchestrator.py
+++ b/the_alchemiser/application/portfolio/rebalancing_orchestrator.py
@@ -1,4 +1,6 @@
-"""Rebalancing Orchestrator for sequential SELL→settle→BUY execution.
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Rebalancing Orchestrator for sequential SELL→settle→BUY execution.
 
 This module provides orchestration for portfolio rebalancing with proper settlement
 timing to avoid buying power issues. It delegates to PortfolioManagementFacade for

--- a/the_alchemiser/application/portfolio/rebalancing_orchestrator_facade.py
+++ b/the_alchemiser/application/portfolio/rebalancing_orchestrator_facade.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Application-layer rebalancing orchestrator facade.
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Application-layer rebalancing orchestrator facade.
 
 This module provides a clean application-layer interface for portfolio rebalancing
 orchestration, reusing existing domain and infrastructure components while providing

--- a/the_alchemiser/application/portfolio/services/__init__.py
+++ b/the_alchemiser/application/portfolio/services/__init__.py
@@ -1,1 +1,4 @@
-"""Portfolio application services."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio application services.
+"""

--- a/the_alchemiser/application/portfolio/services/portfolio_analysis_service.py
+++ b/the_alchemiser/application/portfolio/services/portfolio_analysis_service.py
@@ -1,4 +1,7 @@
-"""Portfolio analysis service - provides comprehensive portfolio analysis."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio analysis service - provides comprehensive portfolio analysis.
+"""
 
 from decimal import Decimal
 from typing import Any

--- a/the_alchemiser/application/portfolio/services/portfolio_management_facade.py
+++ b/the_alchemiser/application/portfolio/services/portfolio_management_facade.py
@@ -1,4 +1,7 @@
-"""Portfolio management facade - unified interface for all portfolio operations."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio management facade - unified interface for all portfolio operations.
+"""
 
 import logging
 from decimal import Decimal

--- a/the_alchemiser/application/portfolio/services/portfolio_rebalancing_service.py
+++ b/the_alchemiser/application/portfolio/services/portfolio_rebalancing_service.py
@@ -1,4 +1,7 @@
-"""Portfolio rebalancing service - main application orchestrator."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio rebalancing service - main application orchestrator.
+"""
 
 from decimal import Decimal
 from typing import Any

--- a/the_alchemiser/application/portfolio/services/rebalance_execution_service.py
+++ b/the_alchemiser/application/portfolio/services/rebalance_execution_service.py
@@ -1,4 +1,7 @@
-"""Rebalance execution service - handles trade execution for rebalancing."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Rebalance execution service - handles trade execution for rebalancing.
+"""
 
 from decimal import Decimal
 from typing import Any

--- a/the_alchemiser/application/reporting/__init__.py
+++ b/the_alchemiser/application/reporting/__init__.py
@@ -1,4 +1,6 @@
-"""Reporting and analytics layer.
+"""Business Unit: utilities; Status: current.
+
+Reporting and analytics layer.
 
 This module contains reporting functionality for trading performance,
 portfolio analysis, and system monitoring.

--- a/the_alchemiser/application/reporting/reporting.py
+++ b/the_alchemiser/application/reporting/reporting.py
@@ -1,4 +1,7 @@
-"""Helpers for building execution summaries and dashboard data."""
+"""Business Unit: utilities; Status: current.
+
+Helpers for building execution summaries and dashboard data.
+"""
 
 import logging
 from typing import Any

--- a/the_alchemiser/application/tracking/__init__.py
+++ b/the_alchemiser/application/tracking/__init__.py
@@ -1,1 +1,4 @@
-"""Strategy tracking package for The Alchemiser."""
+"""Business Unit: utilities; Status: current.
+
+Strategy tracking package for The Alchemiser.
+"""

--- a/the_alchemiser/application/tracking/integration.py
+++ b/the_alchemiser/application/tracking/integration.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Trading Engine Integration for Strategy Order Tracker.
+"""Business Unit: utilities; Status: current.
+
+Trading Engine Integration for Strategy Order Tracker.
 
 This module provides integration between the trading engine and strategy order tracker
 to automatically capture and track orders by strategy for P&L calculations.

--- a/the_alchemiser/application/tracking/strategy_order_tracker.py
+++ b/the_alchemiser/application/tracking/strategy_order_tracker.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Strategy Order Tracker for Per-Strategy P&L Management.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy Order Tracker for Per-Strategy P&L Management.
 
 This module provides dedicated tracking of orders and positions per strategy for accurate P&L calculations.
 It persists order data and calculates realized/unrealized P&L per strategy.

--- a/the_alchemiser/application/trading/__init__.py
+++ b/the_alchemiser/application/trading/__init__.py
@@ -1,4 +1,6 @@
-"""Trading engine and core trading functionality.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading engine and core trading functionality.
 
 This module contains the main trading engine, Alpaca client integration,
 and core trading orchestration logic.

--- a/the_alchemiser/application/trading/account_facade.py
+++ b/the_alchemiser/application/trading/account_facade.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Account Facade - Coordinated account, position, and price data access.
+"""Business Unit: order execution/placement; Status: current.
+
+Account Facade - Coordinated account, position, and price data access.
 
 This facade provides a unified interface for account-related operations by coordinating
 between existing services:

--- a/the_alchemiser/application/trading/alpaca_client.py
+++ b/the_alchemiser/application/trading/alpaca_client.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Alpaca Client for Direct API Access.
+"""Business Unit: order execution/placement; Status: current.
+
+Alpaca Client for Direct API Access.
 
 A streamlined, robust wrapper around Alpaca's trading APIs that provides direct access
 to core trading functions. This client has been refactored to use helper modules for
@@ -48,7 +50,6 @@ Example:
     >>> executor = CanonicalOrderExecutor(client.alpaca_manager)
     >>> req = OrderRequest(symbol=Symbol('AAPL'), side=Side('buy'), quantity=Quantity(Decimal('10')), order_type=OrderType('market'), time_in_force=TimeInForce('day'))  # noqa: E501
     >>> result = executor.execute(req)
-
 """
 
 import logging

--- a/the_alchemiser/application/trading/bootstrap.py
+++ b/the_alchemiser/application/trading/bootstrap.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Trading Engine Bootstrap Module.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading Engine Bootstrap Module.
 
 Encapsulates all TradingEngine dependency injection and initialization paths
 into dedicated bootstrap functions that return a typed context bundle.

--- a/the_alchemiser/application/trading/engine_service.py
+++ b/the_alchemiser/application/trading/engine_service.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Trading Engine for The Alchemiser.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading Engine for The Alchemiser.
 
 Unified multi-strategy trading engine for Alpaca, supporting portfolio rebalancing,
 strategy execution, reporting, and dashboard integration.
@@ -18,7 +20,6 @@ Example:
     >>> container = ApplicationContainer.create_for_testing()
     >>> engine = TradingEngine.create_with_di(container=container)
     >>> result = engine.execute_multi_strategy()
-
 """
 
 import logging

--- a/the_alchemiser/application/trading/lifecycle/__init__.py
+++ b/the_alchemiser/application/trading/lifecycle/__init__.py
@@ -1,4 +1,6 @@
-"""Order Lifecycle Management Application Layer.
+"""Business Unit: order execution/placement; Status: current.
+
+Order Lifecycle Management Application Layer.
 
 This package contains the application layer components for order lifecycle
 management, including the state machine manager, event dispatcher, and

--- a/the_alchemiser/application/trading/lifecycle/cli_observer_interface.py
+++ b/the_alchemiser/application/trading/lifecycle/cli_observer_interface.py
@@ -1,4 +1,6 @@
-"""CLI Observer Interface for Lifecycle Events.
+"""Business Unit: order execution/placement; Status: current.
+
+CLI Observer Interface for Lifecycle Events.
 
 Provides a clean Protocol interface for CLI components to subscribe to lifecycle events
 without introducing console printing or rich formatting into the core trading system.

--- a/the_alchemiser/application/trading/lifecycle/dispatcher.py
+++ b/the_alchemiser/application/trading/lifecycle/dispatcher.py
@@ -1,4 +1,7 @@
-"""Lifecycle event dispatcher with thread-safe observer pattern."""
+"""Business Unit: order execution/placement; Status: current.
+
+Lifecycle event dispatcher with thread-safe observer pattern.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/application/trading/lifecycle/manager.py
+++ b/the_alchemiser/application/trading/lifecycle/manager.py
@@ -1,4 +1,7 @@
-"""Order lifecycle state machine manager."""
+"""Business Unit: order execution/placement; Status: current.
+
+Order lifecycle state machine manager.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/application/trading/lifecycle/observers.py
+++ b/the_alchemiser/application/trading/lifecycle/observers.py
@@ -1,4 +1,7 @@
-"""Concrete observer implementations for order lifecycle events."""
+"""Business Unit: order execution/placement; Status: current.
+
+Concrete observer implementations for order lifecycle events.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/application/trading/portfolio_calculations.py
+++ b/the_alchemiser/application/trading/portfolio_calculations.py
@@ -1,4 +1,6 @@
-"""Portfolio calculation utilities (business logic only).
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio calculation utilities (business logic only).
 
 Moved from interface layer to application.trading to maintain layering:
 application may not import interface/cli. Provides pure allocation calculations.

--- a/the_alchemiser/application/trading/ports.py
+++ b/the_alchemiser/application/trading/ports.py
@@ -1,4 +1,6 @@
-"""Application-layer ports module for trading engine.
+"""Business Unit: order execution/placement; Status: current.
+
+Application-layer ports module for trading engine.
 
 This module aggregates stable Protocol interfaces that the decomposed trading
 engine depends upon. It reuses existing domain protocols and introduces minimal

--- a/the_alchemiser/container/__init__.py
+++ b/the_alchemiser/container/__init__.py
@@ -1,4 +1,7 @@
-"""Dependency injection container package."""
+"""Business Unit: utilities; Status: current.
+
+Dependency injection container package.
+"""
 
 from .application_container import ApplicationContainer
 from .config_providers import ConfigProviders

--- a/the_alchemiser/container/application_container.py
+++ b/the_alchemiser/container/application_container.py
@@ -1,4 +1,7 @@
-"""Main application container for dependency injection."""
+"""Business Unit: utilities; Status: current.
+
+Main application container for dependency injection.
+"""
 
 from dependency_injector import containers, providers
 

--- a/the_alchemiser/container/config_providers.py
+++ b/the_alchemiser/container/config_providers.py
@@ -1,4 +1,7 @@
-"""Configuration providers for dependency injection."""
+"""Business Unit: utilities; Status: current.
+
+Configuration providers for dependency injection.
+"""
 
 from dependency_injector import containers, providers
 

--- a/the_alchemiser/container/infrastructure_providers.py
+++ b/the_alchemiser/container/infrastructure_providers.py
@@ -1,4 +1,7 @@
-"""Infrastructure layer providers for dependency injection."""
+"""Business Unit: utilities; Status: current.
+
+Infrastructure layer providers for dependency injection.
+"""
 
 from dependency_injector import containers, providers
 

--- a/the_alchemiser/container/service_providers.py
+++ b/the_alchemiser/container/service_providers.py
@@ -1,4 +1,7 @@
-"""Service layer providers for dependency injection."""
+"""Business Unit: utilities; Status: current.
+
+Service layer providers for dependency injection.
+"""
 
 from dependency_injector import containers, providers
 

--- a/the_alchemiser/domain/__init__.py
+++ b/the_alchemiser/domain/__init__.py
@@ -1,4 +1,6 @@
-"""Domain layer root package.
+"""Business Unit: utilities; Status: current.
+
+Domain layer root package.
 
 This package contains pure domain models, value objects, entities, and
 protocols. Keep this layer free from framework and infrastructure dependencies.

--- a/the_alchemiser/domain/dsl/__init__.py
+++ b/the_alchemiser/domain/dsl/__init__.py
@@ -1,4 +1,6 @@
-"""S-expression Strategy DSL Engine.
+"""Business Unit: utilities; Status: current.
+
+S-expression Strategy DSL Engine.
 
 A minimal, secure DSL for evaluating trading strategies written as S-expressions.
 Provides deterministic evaluation with structured tracing and strict whitelisting.

--- a/the_alchemiser/domain/dsl/ast.py
+++ b/the_alchemiser/domain/dsl/ast.py
@@ -1,4 +1,6 @@
-"""AST node definitions for the S-expression Strategy DSL.
+"""Business Unit: utilities; Status: current.
+
+AST node definitions for the S-expression Strategy DSL.
 
 Defines dataclasses for all supported DSL constructs with type safety
 and clear semantics for evaluation.

--- a/the_alchemiser/domain/dsl/errors.py
+++ b/the_alchemiser/domain/dsl/errors.py
@@ -1,4 +1,6 @@
-"""DSL-specific exceptions for the S-expression Strategy Engine.
+"""Business Unit: utilities; Status: current.
+
+DSL-specific exceptions for the S-expression Strategy Engine.
 
 Provides clear, actionable error messages with context about what went wrong
 and suggestions for fixing DSL syntax or evaluation issues.

--- a/the_alchemiser/domain/dsl/evaluator.py
+++ b/the_alchemiser/domain/dsl/evaluator.py
@@ -1,4 +1,6 @@
-"""Pure DSL evaluator for the S-expression Strategy Engine.
+"""Business Unit: utilities; Status: current.
+
+Pure DSL evaluator for the S-expression Strategy Engine.
 Evaluates parsed AST nodes into portfolio weights using whitelisted functions
 and market data access. Provides deterministic evaluation with structured tracing.
 """

--- a/the_alchemiser/domain/dsl/evaluator_cache.py
+++ b/the_alchemiser/domain/dsl/evaluator_cache.py
@@ -1,4 +1,6 @@
-"""Evaluation context & caching utilities for DSL evaluator memoisation.
+"""Business Unit: utilities; Status: current.
+
+Evaluation context & caching utilities for DSL evaluator memoisation.
 
 Changes (post review hardening):
  - Replaced hybrid functools.lru_cache approach with a true thread-safe

--- a/the_alchemiser/domain/dsl/interning.py
+++ b/the_alchemiser/domain/dsl/interning.py
@@ -1,4 +1,6 @@
-"""AST interning system for structural sharing (hash-consing).
+"""Business Unit: utilities; Status: current.
+
+AST interning system for structural sharing (hash-consing).
 
 Converts AST trees to DAGs by deduplicating identical subtrees,
 dramatically reducing memory usage and node traversal work for

--- a/the_alchemiser/domain/dsl/optimization_config.py
+++ b/the_alchemiser/domain/dsl/optimization_config.py
@@ -1,4 +1,6 @@
-"""Configuration system for DSL optimization features.
+"""Business Unit: utilities; Status: current.
+
+Configuration system for DSL optimization features.
 
 Provides environment variable and programmatic configuration for
 enabling/disabling AST interning, evaluator memoisation, and parallel execution.

--- a/the_alchemiser/domain/dsl/parser.py
+++ b/the_alchemiser/domain/dsl/parser.py
@@ -1,4 +1,6 @@
-"""S-expression parser with Clojure vector [] support for trading strategy DSL.
+"""Business Unit: utilities; Status: current.
+
+S-expression parser with Clojure vector [] support for trading strategy DSL.
 
 Vectors act as grouping constructs. For portfolio / selector constructs they
 are flattened into the surrounding argument list. For conditional branches a

--- a/the_alchemiser/domain/dsl/strategy_loader.py
+++ b/the_alchemiser/domain/dsl/strategy_loader.py
@@ -1,4 +1,6 @@
-"""Strategy loader for DSL files.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy loader for DSL files.
 
 Loads, parses, and evaluates strategy files written in the S-expression DSL.
 Provides integration with the existing trading system infrastructure.

--- a/the_alchemiser/domain/interfaces/__init__.py
+++ b/the_alchemiser/domain/interfaces/__init__.py
@@ -1,4 +1,6 @@
-"""Domain Layer Interfaces.
+"""Business Unit: utilities; Status: current.
+
+Domain Layer Interfaces.
 
 This module defines the core interfaces for our trading system, following the
 eventual architecture vision while being compatible with current implementations.

--- a/the_alchemiser/domain/interfaces/account_repository.py
+++ b/the_alchemiser/domain/interfaces/account_repository.py
@@ -1,4 +1,6 @@
-"""Account Repository Interface.
+"""Business Unit: utilities; Status: current.
+
+Account Repository Interface.
 
 This interface defines the contract for all account-related operations including
 account information, portfolio data, and balance management.

--- a/the_alchemiser/domain/interfaces/market_data_repository.py
+++ b/the_alchemiser/domain/interfaces/market_data_repository.py
@@ -1,4 +1,6 @@
-"""Market Data Repository Interface.
+"""Business Unit: utilities; Status: current.
+
+Market Data Repository Interface.
 
 This interface defines the contract for all market data operations including
 current prices, quotes, historical data, and streaming data.

--- a/the_alchemiser/domain/interfaces/trading_repository.py
+++ b/the_alchemiser/domain/interfaces/trading_repository.py
@@ -1,4 +1,6 @@
-"""Trading Repository Interface.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading Repository Interface.
 
 This interface defines the contract for all trading operations including order
 placement, position management, and portfolio operations.

--- a/the_alchemiser/domain/market_data/__init__.py
+++ b/the_alchemiser/domain/market_data/__init__.py
@@ -1,1 +1,4 @@
-"""Domain market data package."""
+"""Business Unit: utilities; Status: current.
+
+Domain market data package.
+"""

--- a/the_alchemiser/domain/market_data/models/bar.py
+++ b/the_alchemiser/domain/market_data/models/bar.py
@@ -1,4 +1,6 @@
-"""Domain model for an OHLCV bar.
+"""Business Unit: utilities; Status: current.
+
+Domain model for an OHLCV bar.
 
 Use Decimal for all financial quantities. Keep domain framework-free.
 """

--- a/the_alchemiser/domain/market_data/models/quote.py
+++ b/the_alchemiser/domain/market_data/models/quote.py
@@ -1,4 +1,7 @@
-"""Domain model for a bid/ask quote."""
+"""Business Unit: utilities; Status: current.
+
+Domain model for a bid/ask quote.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/domain/market_data/protocols/market_data_port.py
+++ b/the_alchemiser/domain/market_data/protocols/market_data_port.py
@@ -1,4 +1,6 @@
-"""Domain port for market data access.
+"""Business Unit: utilities; Status: current.
+
+Domain port for market data access.
 
 This port defines the minimal contract strategies need.
 """

--- a/the_alchemiser/domain/math/__init__.py
+++ b/the_alchemiser/domain/math/__init__.py
@@ -1,1 +1,4 @@
-"""Indicator calculation utilities."""
+"""Business Unit: utilities; Status: current.
+
+Indicator calculation utilities.
+"""

--- a/the_alchemiser/domain/math/asset_info.py
+++ b/the_alchemiser/domain/math/asset_info.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Asset Information Utilities.
+"""Business Unit: utilities; Status: current.
+
+Asset Information Utilities.
 
 Handles asset-specific information like fractionability, ETF types, and trading characteristics.
 This helps optimize order placement strategies for different asset types.

--- a/the_alchemiser/domain/math/indicator_utils.py
+++ b/the_alchemiser/domain/math/indicator_utils.py
@@ -1,4 +1,6 @@
-"""Indicator utility functions for safe calculation and error handling.
+"""Business Unit: utilities; Status: current.
+
+Indicator utility functions for safe calculation and error handling.
 
 This module provides helper functions for safely calculating and retrieving technical indicator values.
 """

--- a/the_alchemiser/domain/math/indicators.py
+++ b/the_alchemiser/domain/math/indicators.py
@@ -1,4 +1,6 @@
-"""Technical indicators for trading strategies.
+"""Business Unit: utilities; Status: current.
+
+Technical indicators for trading strategies.
 
 This module provides technical analysis indicators used by trading strategies
 in The Alchemiser quantitative trading system. All indicators are implemented using pandas

--- a/the_alchemiser/domain/math/market_timing_utils.py
+++ b/the_alchemiser/domain/math/market_timing_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Market Open Timing Utilities.
+"""Business Unit: utilities; Status: current.
+
+Market Open Timing Utilities.
 
 Implements the timing logic from better orders spec for optimal execution
 during market open hours (9:30-9:35 ET).

--- a/the_alchemiser/domain/math/math_utils.py
+++ b/the_alchemiser/domain/math/math_utils.py
@@ -1,4 +1,6 @@
-"""Mathematical Utilities for Trading Strategies.
+"""Business Unit: utilities; Status: current.
+
+Mathematical Utilities for Trading Strategies.
 
 This module provides statistical and mathematical functions commonly used
 across different trading strategies, particularly for return calculations,

--- a/the_alchemiser/domain/math/trading_math.py
+++ b/the_alchemiser/domain/math/trading_math.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Trading Math Utilities for The Alchemiser Quantitative Trading System.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading Math Utilities for The Alchemiser Quantitative Trading System.
 
 This module contains pure mathematical functions for trading calculations,
 including position sizing, dynamic limit price calculation, slippage calculations,

--- a/the_alchemiser/domain/models/__init__.py
+++ b/the_alchemiser/domain/models/__init__.py
@@ -1,4 +1,6 @@
-"""Domain models for the trading system.
+"""Business Unit: utilities; Status: current.
+
+Domain models for the trading system.
 
 This package contains typed domain models that replace loose dict/DataFrame structures
 throughout the system. These models provide type safety, validation, and serialization.

--- a/the_alchemiser/domain/models/account.py
+++ b/the_alchemiser/domain/models/account.py
@@ -1,4 +1,7 @@
-"""Account domain models."""
+"""Business Unit: utilities; Status: current.
+
+Account domain models.
+"""
 
 from dataclasses import dataclass
 from typing import Literal

--- a/the_alchemiser/domain/models/market_data.py
+++ b/the_alchemiser/domain/models/market_data.py
@@ -1,4 +1,7 @@
-"""Market data domain models."""
+"""Business Unit: utilities; Status: current.
+
+Market data domain models.
+"""
 
 from dataclasses import dataclass
 from datetime import datetime

--- a/the_alchemiser/domain/models/order.py
+++ b/the_alchemiser/domain/models/order.py
@@ -1,4 +1,7 @@
-"""Order domain models."""
+"""Business Unit: order execution/placement; Status: current.
+
+Order domain models.
+"""
 
 from dataclasses import dataclass
 from datetime import datetime

--- a/the_alchemiser/domain/models/position.py
+++ b/the_alchemiser/domain/models/position.py
@@ -1,4 +1,7 @@
-"""Position domain models."""
+"""Business Unit: utilities; Status: current.
+
+Position domain models.
+"""
 
 from dataclasses import dataclass
 from typing import Literal

--- a/the_alchemiser/domain/models/strategy.py
+++ b/the_alchemiser/domain/models/strategy.py
@@ -1,4 +1,7 @@
-"""Strategy domain models."""
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy domain models.
+"""
 
 from dataclasses import dataclass
 from typing import Literal, cast

--- a/the_alchemiser/domain/policies/__init__.py
+++ b/the_alchemiser/domain/policies/__init__.py
@@ -1,4 +1,6 @@
-"""Domain policy public exports (pure domain only).
+"""Business Unit: utilities; Status: current.
+
+Domain policy public exports (pure domain only).
 
 Exports only pure domain constructs - no interface/DTO layer leakage.
 """

--- a/the_alchemiser/domain/policies/base_policy.py
+++ b/the_alchemiser/domain/policies/base_policy.py
@@ -1,4 +1,6 @@
-"""Base Policy Protocol
+"""Business Unit: utilities; Status: current.
+
+Base Policy Protocol
 
 Defines the common interface that all order validation policies must implement.
 Uses pure domain objects to maintain domain layer purity.

--- a/the_alchemiser/domain/policies/buying_power_policy.py
+++ b/the_alchemiser/domain/policies/buying_power_policy.py
@@ -1,4 +1,6 @@
-"""Buying Power Policy Interface
+"""Business Unit: utilities; Status: current.
+
+Buying Power Policy Interface
 
 Handles validation of order values against available buying power.
 """

--- a/the_alchemiser/domain/policies/fractionability_policy.py
+++ b/the_alchemiser/domain/policies/fractionability_policy.py
@@ -1,4 +1,6 @@
-"""Fractionability Policy Interface
+"""Business Unit: utilities; Status: current.
+
+Fractionability Policy Interface
 
 Handles validation and adjustment of order quantities based on asset fractionability rules.
 """

--- a/the_alchemiser/domain/policies/policy_result.py
+++ b/the_alchemiser/domain/policies/policy_result.py
@@ -1,4 +1,6 @@
-"""Pure domain policy result objects.
+"""Business Unit: utilities; Status: current.
+
+Pure domain policy result objects.
 
 These value objects represent the results of policy validation and adjustment
 without any dependencies on external frameworks or DTOs. They are used within

--- a/the_alchemiser/domain/policies/position_policy.py
+++ b/the_alchemiser/domain/policies/position_policy.py
@@ -1,4 +1,6 @@
-"""Position Policy Interface
+"""Business Unit: utilities; Status: current.
+
+Position Policy Interface
 
 Handles validation and adjustment of order quantities based on current positions.
 """

--- a/the_alchemiser/domain/policies/protocols.py
+++ b/the_alchemiser/domain/policies/protocols.py
@@ -1,4 +1,6 @@
-"""Protocol interfaces for external dependencies used by policies.
+"""Business Unit: utilities; Status: current.
+
+Protocol interfaces for external dependencies used by policies.
 
 These protocols define the minimal interface contracts that policies need
 from external services, providing type safety while maintaining loose coupling.

--- a/the_alchemiser/domain/policies/risk_policy.py
+++ b/the_alchemiser/domain/policies/risk_policy.py
@@ -1,4 +1,6 @@
-"""Risk Policy Interface
+"""Business Unit: utilities; Status: current.
+
+Risk Policy Interface
 
 Handles risk assessment and limits for order requests.
 """

--- a/the_alchemiser/domain/portfolio/__init__.py
+++ b/the_alchemiser/domain/portfolio/__init__.py
@@ -1,1 +1,4 @@
-"""Portfolio domain module containing pure business logic for portfolio management."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio domain module containing pure business logic for portfolio management.
+"""

--- a/the_alchemiser/domain/portfolio/position/__init__.py
+++ b/the_alchemiser/domain/portfolio/position/__init__.py
@@ -1,1 +1,4 @@
-"""Position analysis domain logic and value objects."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Position analysis domain logic and value objects.
+"""

--- a/the_alchemiser/domain/portfolio/position/position_analyzer.py
+++ b/the_alchemiser/domain/portfolio/position/position_analyzer.py
@@ -1,4 +1,7 @@
-"""Pure position delta calculation logic."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Pure position delta calculation logic.
+"""
 
 from decimal import Decimal
 

--- a/the_alchemiser/domain/portfolio/position/position_delta.py
+++ b/the_alchemiser/domain/portfolio/position/position_delta.py
@@ -1,4 +1,7 @@
-"""PositionDelta value object for position change calculations."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+PositionDelta value object for position change calculations.
+"""
 
 from dataclasses import dataclass
 from decimal import Decimal

--- a/the_alchemiser/domain/portfolio/rebalancing/__init__.py
+++ b/the_alchemiser/domain/portfolio/rebalancing/__init__.py
@@ -1,1 +1,4 @@
-"""Rebalancing domain logic and value objects."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Rebalancing domain logic and value objects.
+"""

--- a/the_alchemiser/domain/portfolio/rebalancing/rebalance_calculator.py
+++ b/the_alchemiser/domain/portfolio/rebalancing/rebalance_calculator.py
@@ -1,4 +1,7 @@
-"""Pure calculation logic for portfolio rebalancing."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Pure calculation logic for portfolio rebalancing.
+"""
 
 from decimal import Decimal
 

--- a/the_alchemiser/domain/portfolio/rebalancing/rebalance_plan.py
+++ b/the_alchemiser/domain/portfolio/rebalancing/rebalance_plan.py
@@ -1,4 +1,7 @@
-"""RebalancePlan value object for portfolio rebalancing calculations."""
+"""Business Unit: portfolio assessment & management; Status: current.
+
+RebalancePlan value object for portfolio rebalancing calculations.
+"""
 
 from dataclasses import dataclass
 from decimal import Decimal

--- a/the_alchemiser/domain/portfolio/strategy_attribution/__init__.py
+++ b/the_alchemiser/domain/portfolio/strategy_attribution/__init__.py
@@ -1,1 +1,4 @@
-"""Strategy attribution domain logic."""
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy attribution domain logic.
+"""

--- a/the_alchemiser/domain/portfolio/strategy_attribution/attribution_engine.py
+++ b/the_alchemiser/domain/portfolio/strategy_attribution/attribution_engine.py
@@ -1,4 +1,7 @@
-"""Strategy attribution engine for determining symbol ownership."""
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy attribution engine for determining symbol ownership.
+"""
 
 from decimal import Decimal
 from typing import Any

--- a/the_alchemiser/domain/portfolio/strategy_attribution/symbol_classifier.py
+++ b/the_alchemiser/domain/portfolio/strategy_attribution/symbol_classifier.py
@@ -1,4 +1,7 @@
-"""Symbol classification for strategy attribution."""
+"""Business Unit: strategy & signal generation; Status: current.
+
+Symbol classification for strategy attribution.
+"""
 
 
 class SymbolClassifier:

--- a/the_alchemiser/domain/registry/__init__.py
+++ b/the_alchemiser/domain/registry/__init__.py
@@ -1,4 +1,6 @@
-"""Registry package for The Alchemiser Quantitative Trading System.
+"""Business Unit: utilities; Status: current.
+
+Registry package for The Alchemiser Quantitative Trading System.
 
 This package provides registry-based factories and patterns to replace
 dynamic imports and improve static analysis capabilities.

--- a/the_alchemiser/domain/registry/strategy_registry.py
+++ b/the_alchemiser/domain/registry/strategy_registry.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Strategy Registry for The Alchemiser Quantitative Trading System.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy Registry for The Alchemiser Quantitative Trading System.
 
 This module provides a registry-based approach to strategy management, replacing
 dynamic imports with explicit registration and factory patterns.

--- a/the_alchemiser/domain/services/__init__.py
+++ b/the_alchemiser/domain/services/__init__.py
@@ -1,1 +1,4 @@
-"""Domain service layer containing pure business policies."""
+"""Business Unit: utilities; Status: current.
+
+Domain service layer containing pure business policies.
+"""

--- a/the_alchemiser/domain/services/rebalancing_policy.py
+++ b/the_alchemiser/domain/services/rebalancing_policy.py
@@ -1,4 +1,6 @@
-"""Portfolio rebalancing decision policy.
+"""Business Unit: utilities; Status: current.
+
+Portfolio rebalancing decision policy.
 
 This module houses pure functions that decide how a portfolio should be
 rebalanced based on target allocations and current positions.  The functions

--- a/the_alchemiser/domain/shared_kernel/__init__.py
+++ b/the_alchemiser/domain/shared_kernel/__init__.py
@@ -1,4 +1,6 @@
-"""Shared kernel: cross-context value objects and errors.
+"""Business Unit: utilities; Status: current.
+
+Shared kernel: cross-context value objects and errors.
 
 This package must remain framework-agnostic and side-effect free.
 """

--- a/the_alchemiser/domain/shared_kernel/types.py
+++ b/the_alchemiser/domain/shared_kernel/types.py
@@ -1,4 +1,7 @@
-"""Shared kernel type exports for cross-context value objects."""
+"""Business Unit: utilities; Status: current.
+
+Shared kernel type exports for cross-context value objects.
+"""
 
 from .value_objects.identifier import Identifier
 from .value_objects.money import Money

--- a/the_alchemiser/domain/shared_kernel/value_objects/identifier.py
+++ b/the_alchemiser/domain/shared_kernel/value_objects/identifier.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/shared_kernel/value_objects/money.py
+++ b/the_alchemiser/domain/shared_kernel/value_objects/money.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/shared_kernel/value_objects/percentage.py
+++ b/the_alchemiser/domain/shared_kernel/value_objects/percentage.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/shared_kernel/value_objects/symbol.py
+++ b/the_alchemiser/domain/shared_kernel/value_objects/symbol.py
@@ -1,4 +1,6 @@
-"""Typed value object for Symbols used across the domain.
+"""Business Unit: utilities; Status: current.
+
+Typed value object for Symbols used across the domain.
 
 Keep domain free of external libs; normalize to upper-case and strip whitespace.
 """

--- a/the_alchemiser/domain/strategies/__init__.py
+++ b/the_alchemiser/domain/strategies/__init__.py
@@ -1,1 +1,4 @@
-"""Trading strategy engines and orchestration."""
+"""Business Unit: utilities; Status: current.
+
+Trading strategy engines and orchestration.
+"""

--- a/the_alchemiser/domain/strategies/engine.py
+++ b/the_alchemiser/domain/strategies/engine.py
@@ -1,4 +1,6 @@
-"""Typed Strategy Engine Base Class.
+"""Business Unit: utilities; Status: current.
+
+Typed Strategy Engine Base Class.
 
 Abstract base class for trading strategy implementations with full type safety,
 validation helpers, and error handling integration. This replaces pandas coupling

--- a/the_alchemiser/domain/strategies/entities/__init__.py
+++ b/the_alchemiser/domain/strategies/entities/__init__.py
@@ -1,1 +1,4 @@
-"""Strategy domain entities package."""
+"""Business Unit: utilities; Status: current.
+
+Strategy domain entities package.
+"""

--- a/the_alchemiser/domain/strategies/klm_workers/__init__.py
+++ b/the_alchemiser/domain/strategies/klm_workers/__init__.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Workers Package.
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Workers Package.
 
 This package contains all individual strategy variants for the KLM ensemble system.
 Each variant is implemented as a separate module for better maintainability.

--- a/the_alchemiser/domain/strategies/klm_workers/base_klm_variant.py
+++ b/the_alchemiser/domain/strategies/klm_workers/base_klm_variant.py
@@ -1,4 +1,6 @@
-"""Base KLM Strategy Variant.
+"""Business Unit: utilities; Status: current.
+
+Base KLM Strategy Variant.
 
 Abstract base class for all KLM strategy variants. Provides common functionality
 and enforces a consistent interface across all variants.

--- a/the_alchemiser/domain/strategies/klm_workers/variant_1200_28.py
+++ b/the_alchemiser/domain/strategies/klm_workers/variant_1200_28.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Variant 1200/28 - "KMLM (43)".
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Variant 1200/28 - "KMLM (43)".
 
 This variant is nearly IDENTICAL to 506/38 except:
 - KMLM Switcher uses select-bottom 1 from TECL/SOXL/SVIX (instead of FNGU)

--- a/the_alchemiser/domain/strategies/klm_workers/variant_1280_26.py
+++ b/the_alchemiser/domain/strategies/klm_workers/variant_1280_26.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Variant 1280/26 - "KMLM (50)".
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Variant 1280/26 - "KMLM (50)".
 
 COMPLETELY DIFFERENT from 506/38! This variant:
 1. Uses standard overbought detection → UVXY

--- a/the_alchemiser/domain/strategies/klm_workers/variant_410_38.py
+++ b/the_alchemiser/domain/strategies/klm_workers/variant_410_38.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Variant 410/38 - "MonkeyBusiness Simons variant".
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Variant 410/38 - "MonkeyBusiness Simons variant".
 
 This variant is IDENTICAL to 506/38 except:
 - L/S Rotator uses FTLS/KMLM/SSO/UUP (includes SSO)

--- a/the_alchemiser/domain/strategies/klm_workers/variant_506_38.py
+++ b/the_alchemiser/domain/strategies/klm_workers/variant_506_38.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Variant 506/38 - "KMLM (13) - Longer BT".
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Variant 506/38 - "KMLM (13) - Longer BT".
 
 This is the first variant in the Clojure strategy ensemble. It follows the standard
 overbought detection pattern followed by "Single Popped KMLM" logic.

--- a/the_alchemiser/domain/strategies/klm_workers/variant_520_22.py
+++ b/the_alchemiser/domain/strategies/klm_workers/variant_520_22.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Variant 520/22 - "KMLM (23) - Original".
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Variant 520/22 - "KMLM (23) - Original".
 
 This variant is similar to 506/38 and 1200/28 except:
 - KMLM Switcher uses select-bottom 1 from TECL/SVIX only (no SOXL, no FNGU)

--- a/the_alchemiser/domain/strategies/klm_workers/variant_530_18.py
+++ b/the_alchemiser/domain/strategies/klm_workers/variant_530_18.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Variant 530/18 - "KMLM Switcher | Anansi Mods".
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Variant 530/18 - "KMLM Switcher | Anansi Mods".
 
 This is the Scale-In strategy variant - the most complex in the ensemble.
 It uses progressive VIX allocation based on multiple RSI conditions.

--- a/the_alchemiser/domain/strategies/klm_workers/variant_830_21.py
+++ b/the_alchemiser/domain/strategies/klm_workers/variant_830_21.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Variant 830/21 - "MonkeyBusiness Simons variant V2".
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Variant 830/21 - "MonkeyBusiness Simons variant V2".
 
 This variant is similar to other standard variants except:
 1. KMLM Switcher uses select-TOP 1 from TECL/SOXL/SVIX (opposite of others)

--- a/the_alchemiser/domain/strategies/klm_workers/variant_nova.py
+++ b/the_alchemiser/domain/strategies/klm_workers/variant_nova.py
@@ -1,4 +1,6 @@
-"""KLM Strategy Variant Nova - "Nerfed 2900/8 (373) - Nova - Short BT".
+"""Business Unit: utilities; Status: current.
+
+KLM Strategy Variant Nova - "Nerfed 2900/8 (373) - Nova - Short BT".
 
 This variant is DIFFERENT from others in several key ways:
 1. Uses UVIX instead of UVXY in Single Popped KMLM check

--- a/the_alchemiser/domain/strategies/models/__init__.py
+++ b/the_alchemiser/domain/strategies/models/__init__.py
@@ -1,4 +1,6 @@
-"""Strategy domain models package.
+"""Business Unit: utilities; Status: current.
+
+Strategy domain models package.
 
 This package provides strongly-typed models for strategy domain objects using
 domain value objects and Decimal for financial precision.

--- a/the_alchemiser/domain/strategies/models/strategy_position_model.py
+++ b/the_alchemiser/domain/strategies/models/strategy_position_model.py
@@ -1,4 +1,7 @@
-"""Strategy position model using domain value objects."""
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy position model using domain value objects.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/domain/strategies/models/strategy_signal_model.py
+++ b/the_alchemiser/domain/strategies/models/strategy_signal_model.py
@@ -1,4 +1,7 @@
-"""Strategy signal model using domain value objects."""
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy signal model using domain value objects.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/domain/strategies/nuclear_logic.py
+++ b/the_alchemiser/domain/strategies/nuclear_logic.py
@@ -1,4 +1,6 @@
-"""Pure evaluation logic for the Nuclear strategy (typed, framework-free).
+"""Business Unit: utilities; Status: current.
+
+Pure evaluation logic for the Nuclear strategy (typed, framework-free).
 
 This module exposes a small, pure function used by the typed Nuclear engine
 to decide the recommended symbol, action, and reasoning from precomputed

--- a/the_alchemiser/domain/strategies/nuclear_typed_engine.py
+++ b/the_alchemiser/domain/strategies/nuclear_typed_engine.py
@@ -1,4 +1,6 @@
-"""Typed Nuclear Strategy Engine.
+"""Business Unit: utilities; Status: current.
+
+Typed Nuclear Strategy Engine.
 
 Typed implementation of the Nuclear energy trading strategy that inherits from
 StrategyEngine and uses MarketDataPort for data access. Produces StrategySignal

--- a/the_alchemiser/domain/strategies/protocols/__init__.py
+++ b/the_alchemiser/domain/strategies/protocols/__init__.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from the_alchemiser.domain.strategies.protocols.strategy_engine import StrategyEngine
 
 # DEPRECATION NOTICE: MarketDataPort from this module is deprecated.

--- a/the_alchemiser/domain/strategies/protocols/strategy_engine.py
+++ b/the_alchemiser/domain/strategies/protocols/strategy_engine.py
@@ -1,3 +1,5 @@
+"""Business Unit: strategy & signal generation; Status: current."""
+
 from __future__ import annotations
 
 from typing import Protocol, runtime_checkable

--- a/the_alchemiser/domain/strategies/strategy_manager.py
+++ b/the_alchemiser/domain/strategies/strategy_manager.py
@@ -1,0 +1,1 @@
+"""Business Unit: strategy & signal generation; Status: current."""

--- a/the_alchemiser/domain/strategies/tecl_strategy_engine.py
+++ b/the_alchemiser/domain/strategies/tecl_strategy_engine.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""TECL Strategy Engine.
+"""Business Unit: strategy & signal generation; Status: current.
+
+TECL Strategy Engine.
 
 Implements the "TECL For The Long Term (v7)" strategy from Composer.trade.
 This strategy is designed for long-term technology leverage (TECL) with volatility protection.

--- a/the_alchemiser/domain/strategies/typed_klm_ensemble_engine.py
+++ b/the_alchemiser/domain/strategies/typed_klm_ensemble_engine.py
@@ -1,4 +1,6 @@
-"""Typed KLM Strategy Ensemble Engine.
+"""Business Unit: utilities; Status: current.
+
+Typed KLM Strategy Ensemble Engine.
 
 Multi-strategy ensemble system that implements the StrategyEngine protocol
 and generates typed StrategySignal objects. Evaluates all KLM variants and

--- a/the_alchemiser/domain/strategies/typed_strategy_manager.py
+++ b/the_alchemiser/domain/strategies/typed_strategy_manager.py
@@ -1,4 +1,6 @@
-"""Typed Strategy Manager.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Typed Strategy Manager.
 
 Modern strategy orchestrator that depends only on MarketDataPort and typed engines.
 Aggregates typed StrategySignal objects and handles conflict resolution between

--- a/the_alchemiser/domain/strategies/value_objects/alert.py
+++ b/the_alchemiser/domain/strategies/value_objects/alert.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/the_alchemiser/domain/strategies/value_objects/confidence.py
+++ b/the_alchemiser/domain/strategies/value_objects/confidence.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/strategies/value_objects/strategy_signal.py
+++ b/the_alchemiser/domain/strategies/value_objects/strategy_signal.py
@@ -1,3 +1,5 @@
+"""Business Unit: strategy & signal generation; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/the_alchemiser/domain/trading/__init__.py
+++ b/the_alchemiser/domain/trading/__init__.py
@@ -1,4 +1,6 @@
-"""Trading domain package.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading domain package.
 
 Contains entities, value objects and protocols for trading operations.
 Domain layer must remain pure (no infrastructure/library side-effects).

--- a/the_alchemiser/domain/trading/entities/order.py
+++ b/the_alchemiser/domain/trading/entities/order.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/the_alchemiser/domain/trading/errors/__init__.py
+++ b/the_alchemiser/domain/trading/errors/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Order Error Classification System for The Alchemiser Trading System.
+"""Business Unit: order execution/placement; Status: current.
+
+Order Error Classification System for The Alchemiser Trading System.
 
 This module provides structured error classification for order lifecycle and execution paths,
 enabling deterministic branching, richer analytics, and improved user-facing messaging.

--- a/the_alchemiser/domain/trading/errors/classifier.py
+++ b/the_alchemiser/domain/trading/errors/classifier.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Order Error Classifier for mapping exceptions to structured OrderError instances.
+"""Business Unit: order execution/placement; Status: current.
+
+Order Error Classifier for mapping exceptions to structured OrderError instances.
 
 This module provides registry-driven classification of various error types
 into standardized OrderError value objects for consistent error handling.

--- a/the_alchemiser/domain/trading/errors/error_categories.py
+++ b/the_alchemiser/domain/trading/errors/error_categories.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Order Error Categories for structured error classification.
+"""Business Unit: order execution/placement; Status: current.
+
+Order Error Categories for structured error classification.
 
 This module defines the high-level categories for order-related errors,
 enabling consistent classification and handling across the trading system.

--- a/the_alchemiser/domain/trading/errors/error_codes.py
+++ b/the_alchemiser/domain/trading/errors/error_codes.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Specific Order Error Codes mapped to categories.
+"""Business Unit: order execution/placement; Status: current.
+
+Specific Order Error Codes mapped to categories.
 
 This module defines specific error codes that provide precise classification
 of order failures, enabling targeted remediation and analytics.

--- a/the_alchemiser/domain/trading/errors/order_error.py
+++ b/the_alchemiser/domain/trading/errors/order_error.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""OrderError value object for structured error representation.
+"""Business Unit: order execution/placement; Status: current.
+
+OrderError value object for structured error representation.
 
 This module provides the core OrderError value object that encapsulates
 all information about order-related failures in a structured format.

--- a/the_alchemiser/domain/trading/lifecycle/__init__.py
+++ b/the_alchemiser/domain/trading/lifecycle/__init__.py
@@ -1,4 +1,6 @@
-"""Order Lifecycle Management Domain Components.
+"""Business Unit: order execution/placement; Status: current.
+
+Order Lifecycle Management Domain Components.
 
 This package contains the core domain objects for order lifecycle management,
 including states, events, and protocols for observing lifecycle transitions.

--- a/the_alchemiser/domain/trading/lifecycle/events.py
+++ b/the_alchemiser/domain/trading/lifecycle/events.py
@@ -1,4 +1,7 @@
-"""Order lifecycle events and event types."""
+"""Business Unit: order execution/placement; Status: current.
+
+Order lifecycle events and event types.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/domain/trading/lifecycle/exceptions.py
+++ b/the_alchemiser/domain/trading/lifecycle/exceptions.py
@@ -1,4 +1,7 @@
-"""Order lifecycle management exceptions."""
+"""Business Unit: order execution/placement; Status: current.
+
+Order lifecycle management exceptions.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/domain/trading/lifecycle/protocols.py
+++ b/the_alchemiser/domain/trading/lifecycle/protocols.py
@@ -1,4 +1,7 @@
-"""Observer protocol for order lifecycle events."""
+"""Business Unit: order execution/placement; Status: current.
+
+Observer protocol for order lifecycle events.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/domain/trading/lifecycle/states.py
+++ b/the_alchemiser/domain/trading/lifecycle/states.py
@@ -1,4 +1,7 @@
-"""Order lifecycle state enumeration."""
+"""Business Unit: order execution/placement; Status: current.
+
+Order lifecycle state enumeration.
+"""
 
 from __future__ import annotations
 

--- a/the_alchemiser/domain/trading/lifecycle/transitions.py
+++ b/the_alchemiser/domain/trading/lifecycle/transitions.py
@@ -1,4 +1,6 @@
-"""Domain-level declaration of valid order lifecycle transitions.
+"""Business Unit: order execution/placement; Status: current.
+
+Domain-level declaration of valid order lifecycle transitions.
 
 Separated from application layer so business rules live in domain.
 """

--- a/the_alchemiser/domain/trading/protocols/__init__.py
+++ b/the_alchemiser/domain/trading/protocols/__init__.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from .order_lifecycle import OrderLifecycleMonitor  # noqa: F401

--- a/the_alchemiser/domain/trading/protocols/order_lifecycle.py
+++ b/the_alchemiser/domain/trading/protocols/order_lifecycle.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from typing import Protocol

--- a/the_alchemiser/domain/trading/protocols/trading_repository.py
+++ b/the_alchemiser/domain/trading/protocols/trading_repository.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from typing import Protocol

--- a/the_alchemiser/domain/trading/value_objects/order_id.py
+++ b/the_alchemiser/domain/trading/value_objects/order_id.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/the_alchemiser/domain/trading/value_objects/order_request.py
+++ b/the_alchemiser/domain/trading/value_objects/order_request.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/trading/value_objects/order_status.py
+++ b/the_alchemiser/domain/trading/value_objects/order_status.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from enum import Enum

--- a/the_alchemiser/domain/trading/value_objects/order_status_literal.py
+++ b/the_alchemiser/domain/trading/value_objects/order_status_literal.py
@@ -1,4 +1,6 @@
-"""Canonical lowercase order status literals for system boundaries.
+"""Business Unit: order execution/placement; Status: current.
+
+Canonical lowercase order status literals for system boundaries.
 
 Purpose
 -------

--- a/the_alchemiser/domain/trading/value_objects/order_type.py
+++ b/the_alchemiser/domain/trading/value_objects/order_type.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/trading/value_objects/quantity.py
+++ b/the_alchemiser/domain/trading/value_objects/quantity.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/trading/value_objects/side.py
+++ b/the_alchemiser/domain/trading/value_objects/side.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/trading/value_objects/symbol.py
+++ b/the_alchemiser/domain/trading/value_objects/symbol.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/trading/value_objects/time_in_force.py
+++ b/the_alchemiser/domain/trading/value_objects/time_in_force.py
@@ -1,3 +1,5 @@
+"""Business Unit: order execution/placement; Status: current."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/the_alchemiser/domain/types.py
+++ b/the_alchemiser/domain/types.py
@@ -1,4 +1,6 @@
-"""Core type definitions for The Alchemiser trading system.
+"""Business Unit: utilities; Status: current.
+
+Core type definitions for The Alchemiser trading system.
 
 This module contains domain-appropriate TypedDict definitions that represent
 core business entities and concepts. Interface/UI types have been moved to

--- a/the_alchemiser/execution/account_service.py
+++ b/the_alchemiser/execution/account_service.py
@@ -1,4 +1,7 @@
-"""Account and position management helpers."""
+"""Business Unit: order execution/placement; Status: current.
+
+Account and position management helpers.
+"""
 
 import logging
 from typing import Any, Protocol

--- a/the_alchemiser/infrastructure/__init__.py
+++ b/the_alchemiser/infrastructure/__init__.py
@@ -1,4 +1,6 @@
-"""Infrastructure layer integrations.
+"""Business Unit: utilities; Status: current.
+
+Infrastructure layer integrations.
 
 Adapters to external systems (Alpaca, AWS, WebSocket streaming, secrets, logging).
 Keep side-effects minimal at import time; postpone network/service initialization until

--- a/the_alchemiser/infrastructure/adapters/__init__.py
+++ b/the_alchemiser/infrastructure/adapters/__init__.py
@@ -1,1 +1,4 @@
-"""Infrastructure adapters for legacy system integration."""
+"""Business Unit: utilities; Status: current.
+
+Infrastructure adapters for legacy system integration.
+"""

--- a/the_alchemiser/infrastructure/alerts/__init__.py
+++ b/the_alchemiser/infrastructure/alerts/__init__.py
@@ -1,1 +1,4 @@
-"""Alerting utilities for translating strategy signals into notifications."""
+"""Business Unit: utilities; Status: current.
+
+Alerting utilities for translating strategy signals into notifications.
+"""

--- a/the_alchemiser/infrastructure/alerts/alert_service.py
+++ b/the_alchemiser/infrastructure/alerts/alert_service.py
@@ -1,4 +1,6 @@
-"""Utility functions and classes for generating trading alerts.
+"""Business Unit: utilities; Status: current.
+
+Utility functions and classes for generating trading alerts.
 
 This module centralizes alert creation and logging, providing helpers that
 convert strategy recommendations into structured data that can be persisted or

--- a/the_alchemiser/infrastructure/config/__init__.py
+++ b/the_alchemiser/infrastructure/config/__init__.py
@@ -1,4 +1,7 @@
-"""Configuration package for The Alchemiser Quantitative Trading System."""
+"""Business Unit: utilities; Status: current.
+
+Configuration package for The Alchemiser Quantitative Trading System.
+"""
 
 from .config import Settings, load_settings
 from .execution_config import get_execution_config

--- a/the_alchemiser/infrastructure/config/config.py
+++ b/the_alchemiser/infrastructure/config/config.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/the_alchemiser/infrastructure/config/config_utils.py
+++ b/the_alchemiser/infrastructure/config/config_utils.py
@@ -1,4 +1,6 @@
-"""Configuration Utilities.
+"""Business Unit: utilities; Status: current.
+
+Configuration Utilities.
 
 This module provides helper functions for configuration loading operations.
 """

--- a/the_alchemiser/infrastructure/config/execution_config.py
+++ b/the_alchemiser/infrastructure/config/execution_config.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Execution Configuration.
+"""Business Unit: order execution/placement; Status: current.
+
+Execution Configuration.
 
 Configuration settings for the professional execution system.
 Loads settings from the global application configuration.

--- a/the_alchemiser/infrastructure/data_providers/__init__.py
+++ b/the_alchemiser/infrastructure/data_providers/__init__.py
@@ -1,1 +1,4 @@
-"""Data provider utilities and abstractions."""
+"""Business Unit: utilities; Status: current.
+
+Data provider utilities and abstractions.
+"""

--- a/the_alchemiser/infrastructure/data_providers/real_time_pricing.py
+++ b/the_alchemiser/infrastructure/data_providers/real_time_pricing.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Real-time WebSocket Price Streaming for Alpaca Trading.
+"""Business Unit: utilities; Status: current.
+
+Real-time WebSocket Price Streaming for Alpaca Trading.
 
 This module provides real-time stock price updates via Alpaca's WebSocket streams
 to ensure accurate limit order pricing. It maintains current bid/ask quotes and

--- a/the_alchemiser/infrastructure/logging/__init__.py
+++ b/the_alchemiser/infrastructure/logging/__init__.py
@@ -1,1 +1,4 @@
-"""Logging helpers and structured formatter."""
+"""Business Unit: utilities; Status: current.
+
+Logging helpers and structured formatter.
+"""

--- a/the_alchemiser/infrastructure/logging/logging_utils.py
+++ b/the_alchemiser/infrastructure/logging/logging_utils.py
@@ -1,4 +1,7 @@
-"""Logging helpers for consistent structured output."""
+"""Business Unit: utilities; Status: current.
+
+Logging helpers for consistent structured output.
+"""
 
 import json
 import logging

--- a/the_alchemiser/infrastructure/s3/__init__.py
+++ b/the_alchemiser/infrastructure/s3/__init__.py
@@ -1,0 +1,1 @@
+"""Business Unit: utilities; Status: current."""

--- a/the_alchemiser/infrastructure/s3/s3_utils.py
+++ b/the_alchemiser/infrastructure/s3/s3_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""S3 Utilities for Quantitative Trading System
+"""Business Unit: utilities; Status: current.
+
+S3 Utilities for Quantitative Trading System
 Handles reading and writing files to S3 storage.
 """
 

--- a/the_alchemiser/infrastructure/secrets/__init__.py
+++ b/the_alchemiser/infrastructure/secrets/__init__.py
@@ -1,1 +1,4 @@
-"""Secret management utilities."""
+"""Business Unit: utilities; Status: current.
+
+Secret management utilities.
+"""

--- a/the_alchemiser/infrastructure/secrets/secrets_manager.py
+++ b/the_alchemiser/infrastructure/secrets/secrets_manager.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""AWS Secrets Manager Integration
+"""Business Unit: utilities; Status: current.
+
+AWS Secrets Manager Integration
 Handles retrieving secrets from AWS Secrets Manager for the Quantitative Trading System.
 
 Environment-Aware Behavior:

--- a/the_alchemiser/infrastructure/services/__init__.py
+++ b/the_alchemiser/infrastructure/services/__init__.py
@@ -1,4 +1,6 @@
-"""Infrastructure services package.
+"""Business Unit: utilities; Status: current.
+
+Infrastructure services package.
 
 This package contains infrastructure-level services that provide
 cross-cutting concerns like tick size resolution and slippage analysis.

--- a/the_alchemiser/infrastructure/services/slippage_analyzer.py
+++ b/the_alchemiser/infrastructure/services/slippage_analyzer.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Slippage Post-Fill Analyzer.
+"""Business Unit: utilities; Status: current.
+
+Slippage Post-Fill Analyzer.
 
 Phase 7 Enhancement: Analyzes slippage by comparing intended vs executed prices
 and records results in basis points (bps) for performance monitoring.

--- a/the_alchemiser/infrastructure/services/tick_size_service.py
+++ b/the_alchemiser/infrastructure/services/tick_size_service.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Dynamic Tick Size Service.
+"""Business Unit: utilities; Status: current.
+
+Dynamic Tick Size Service.
 
 Phase 7 Enhancement: Provides symbol-specific tick size resolution
 to replace hardcoded $0.01 values throughout the system.

--- a/the_alchemiser/infrastructure/validation/__init__.py
+++ b/the_alchemiser/infrastructure/validation/__init__.py
@@ -1,4 +1,7 @@
-"""Validation utilities for The Alchemiser Quantitative Trading System."""
+"""Business Unit: utilities; Status: current.
+
+Validation utilities for The Alchemiser Quantitative Trading System.
+"""
 
 from .indicator_validator import IndicatorValidationSuite
 

--- a/the_alchemiser/infrastructure/validation/indicator_validator.py
+++ b/the_alchemiser/infrastructure/validation/indicator_validator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Comprehensive Indicator Validation for The Alchemiser Quantitative Trading System.
+"""Business Unit: utilities; Status: current.
+
+Comprehensive Indicator Validation for The Alchemiser Quantitative Trading System.
 
 This module provides a comprehensive testing suite that validates ALL technical
 indicators used by our trading strategies against TwelveData API values.

--- a/the_alchemiser/infrastructure/websocket/__init__.py
+++ b/the_alchemiser/infrastructure/websocket/__init__.py
@@ -1,0 +1,1 @@
+"""Business Unit: utilities; Status: current."""

--- a/the_alchemiser/infrastructure/websocket/websocket_connection_manager.py
+++ b/the_alchemiser/infrastructure/websocket/websocket_connection_manager.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""WebSocket Connection Manager.
+"""Business Unit: utilities; Status: current.
+
+WebSocket Connection Manager.
 
 This module manages WebSocket connections for order monitoring and real-time data,
 providing connection lifecycle management and cleanup utilities.

--- a/the_alchemiser/infrastructure/websocket/websocket_order_monitor.py
+++ b/the_alchemiser/infrastructure/websocket/websocket_order_monitor.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""WebSocket Order Monitoring Utilities.
+"""Business Unit: order execution/placement; Status: current.
+
+WebSocket Order Monitoring Utilities.
 
 This module provides WebSocket-based order completion monitoring for real-time
 order settlement detection. No legacy polling fallbacks - WebSocket only.

--- a/the_alchemiser/interface/cli/__init__.py
+++ b/the_alchemiser/interface/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Business Unit: utilities; Status: current."""

--- a/the_alchemiser/interface/cli/cli.py
+++ b/the_alchemiser/interface/cli/cli.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Command-Line Interface for The Alchemiser Quantitative Trading System.
+"""Business Unit: utilities; Status: current.
+
+Command-Line Interface for The Alchemiser Quantitative Trading System.
 
 Provides a modern CLI built with Typer and Rich for user interaction, strategy selection,
 and reporting. Handles user commands and displays formatted output.

--- a/the_alchemiser/interface/cli/cli_formatter.py
+++ b/the_alchemiser/interface/cli/cli_formatter.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 from typing import Any
 
 from rich.align import Align

--- a/the_alchemiser/interface/cli/dashboard_utils.py
+++ b/the_alchemiser/interface/cli/dashboard_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Dashboard Data Utilities.
+"""Business Unit: utilities; Status: current.
+
+Dashboard Data Utilities.
 
 This module provides helper functions for building structured data
 for dashboard consumption, including portfolio metrics, positions,

--- a/the_alchemiser/interface/cli/error_display_utils.py
+++ b/the_alchemiser/interface/cli/error_display_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""CLI error display utilities for order error classification.
+"""Business Unit: utilities; Status: current.
+
+CLI error display utilities for order error classification.
 
 This module extends the existing CLI formatting to display classified order errors
 with proper categorization, remediation hints, and visual styling.

--- a/the_alchemiser/interface/cli/portfolio_calculations.py
+++ b/the_alchemiser/interface/cli/portfolio_calculations.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Portfolio calculation utilities extracted from TradingEngine.
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio calculation utilities extracted from TradingEngine.
 
 This module provides calculation functions for portfolio target vs current allocations
 without any display logic, supporting the separation of business logic from presentation.

--- a/the_alchemiser/interface/cli/signal_analyzer.py
+++ b/the_alchemiser/interface/cli/signal_analyzer.py
@@ -1,4 +1,6 @@
-"""Signal analysis CLI module.
+"""Business Unit: utilities; Status: current.
+
+Signal analysis CLI module.
 
 Handles signal generation and display without trading execution.
 """

--- a/the_alchemiser/interface/cli/signal_display_utils.py
+++ b/the_alchemiser/interface/cli/signal_display_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Signal Display Utilities.
+"""Business Unit: utilities; Status: current.
+
+Signal Display Utilities.
 
 This module provides helper functions for displaying and logging signal results
 that are common across different strategy signal generators.

--- a/the_alchemiser/interface/cli/trading_executor.py
+++ b/the_alchemiser/interface/cli/trading_executor.py
@@ -1,4 +1,6 @@
-"""Trading execution CLI module.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading execution CLI module.
 
 Handles trading execution with comprehensive error handling and notifications.
 """

--- a/the_alchemiser/interface/email/__init__.py
+++ b/the_alchemiser/interface/email/__init__.py
@@ -1,4 +1,6 @@
-"""Email module for The Alchemiser quantitative trading system.
+"""Business Unit: utilities; Status: current.
+
+Email module for The Alchemiser quantitative trading system.
 
 This module provides email notification functionality with clean separation
 of concerns across configuration, client operations, and template generation.

--- a/the_alchemiser/interface/email/client.py
+++ b/the_alchemiser/interface/email/client.py
@@ -1,4 +1,6 @@
-"""Email client module for sending notifications.
+"""Business Unit: utilities; Status: current.
+
+Email client module for sending notifications.
 
 This module handles SMTP operations and message sending functionality.
 Replaces the `send_email_notification` function from the original email_utils.py.

--- a/the_alchemiser/interface/email/config.py
+++ b/the_alchemiser/interface/email/config.py
@@ -1,4 +1,6 @@
-"""Email configuration management module.
+"""Business Unit: utilities; Status: current.
+
+Email configuration management module.
 
 This module handles loading email settings from environment variables and AWS Secrets Manager.
 Replaces the `get_email_config` function from the original email_utils.py.

--- a/the_alchemiser/interface/email/email_utils.py
+++ b/the_alchemiser/interface/email/email_utils.py
@@ -1,4 +1,6 @@
-"""Email utilities module - REFACTORED.
+"""Business Unit: utilities; Status: current.
+
+Email utilities module - REFACTORED.
 
 This module now imports from the new modular email system for backward compatibility.
 The email functionality has been split into separate modules:

--- a/the_alchemiser/interface/email/templates/__init__.py
+++ b/the_alchemiser/interface/email/templates/__init__.py
@@ -1,4 +1,6 @@
-"""Email templates module for The Alchemiser.
+"""Business Unit: utilities; Status: current.
+
+Email templates module for The Alchemiser.
 
 This module provides email template builders with clean separation of concerns.
 Each template type has its own dedicated module for better organization.

--- a/the_alchemiser/interface/email/templates/base.py
+++ b/the_alchemiser/interface/email/templates/base.py
@@ -1,4 +1,6 @@
-"""Base HTML email template module.
+"""Business Unit: utilities; Status: current.
+
+Base HTML email template module.
 
 This module provides the core HTML template structure and common styling
 used across all email types.

--- a/the_alchemiser/interface/email/templates/error_report.py
+++ b/the_alchemiser/interface/email/templates/error_report.py
@@ -1,4 +1,6 @@
-"""Error report template builder.
+"""Business Unit: utilities; Status: current.
+
+Error report template builder.
 
 This module handles error notification email template generation.
 """

--- a/the_alchemiser/interface/email/templates/multi_strategy.py
+++ b/the_alchemiser/interface/email/templates/multi_strategy.py
@@ -1,4 +1,6 @@
-"""Multi-strategy report template builder.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Multi-strategy report template builder.
 
 This module handles the multi-strategy email template generation.
 """

--- a/the_alchemiser/interface/email/templates/performance.py
+++ b/the_alchemiser/interface/email/templates/performance.py
@@ -1,4 +1,6 @@
-"""Performance content builder for email templates.
+"""Business Unit: utilities; Status: current.
+
+Performance content builder for email templates.
 
 This module handles building HTML content for trading summaries,
 order execution reports, and performance metrics.

--- a/the_alchemiser/interface/email/templates/portfolio.py
+++ b/the_alchemiser/interface/email/templates/portfolio.py
@@ -1,4 +1,6 @@
-"""Portfolio content builder for email templates.
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio content builder for email templates.
 
 Builds HTML content for portfolio tables, position summaries, allocations, and
 neutral-mode representations. This version removes the ad-hoc ExtendedAccountInfo

--- a/the_alchemiser/interface/email/templates/signals.py
+++ b/the_alchemiser/interface/email/templates/signals.py
@@ -1,4 +1,6 @@
-"""Signals content builder for email templates.
+"""Business Unit: utilities; Status: current.
+
+Signals content builder for email templates.
 
 This module handles building HTML content for technical indicators,
 strategy signals, and trading signal analysis.

--- a/the_alchemiser/interface/email/templates/trading_report.py
+++ b/the_alchemiser/interface/email/templates/trading_report.py
@@ -1,4 +1,6 @@
-"""Main trading report template builder.
+"""Business Unit: order execution/placement; Status: current.
+
+Main trading report template builder.
 
 This module handles the primary trading report email template generation.
 """

--- a/the_alchemiser/interfaces/__init__.py
+++ b/the_alchemiser/interfaces/__init__.py
@@ -1,4 +1,6 @@
-"""Interfaces layer for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Interfaces layer for The Alchemiser Trading System.
 
 This package contains DTOs, schemas, and interface definitions that define
 the contract between different layers of the application.

--- a/the_alchemiser/interfaces/schemas/__init__.py
+++ b/the_alchemiser/interfaces/schemas/__init__.py
@@ -1,4 +1,6 @@
-"""Schemas package for DTOs used at system boundaries.
+"""Business Unit: utilities; Status: current.
+
+Schemas package for DTOs used at system boundaries.
 
 This package contains Pydantic models for data transfer objects (DTOs) used by
 the application layer and interfaces. These DTOs provide type safety and validation

--- a/the_alchemiser/interfaces/schemas/accounts.py
+++ b/the_alchemiser/interfaces/schemas/accounts.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Account DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Account DTOs for The Alchemiser Trading System.
 
 This module contains DTOs for account data, buying power checks, risk metrics,
 and account-related operations.

--- a/the_alchemiser/interfaces/schemas/alpaca.py
+++ b/the_alchemiser/interfaces/schemas/alpaca.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Alpaca Infrastructure DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Alpaca Infrastructure DTOs for The Alchemiser Trading System.
 
 This module provides Pydantic v2 DTOs for Alpaca API responses, ensuring
 typed boundaries at the infrastructure layer. These DTOs map directly

--- a/the_alchemiser/interfaces/schemas/base.py
+++ b/the_alchemiser/interfaces/schemas/base.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Base DTO primitives used across result-oriented response models.
+"""Business Unit: utilities; Status: current.
+
+Base DTO primitives used across result-oriented response models.
 
 Provides a single place for the ubiquitous success / error pattern to
 eliminate duplication and ensure uniform semantics across facade methods.

--- a/the_alchemiser/interfaces/schemas/cli.py
+++ b/the_alchemiser/interfaces/schemas/cli.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""CLI-related DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+CLI-related DTOs for The Alchemiser Trading System.
 
 This module contains Pydantic v2 DTOs for CLI interface boundaries,
 moved from domain/types.py as part of the Pydantic migration.

--- a/the_alchemiser/interfaces/schemas/common.py
+++ b/the_alchemiser/interfaces/schemas/common.py
@@ -1,4 +1,6 @@
-"""Common DTOs for application layer and interface boundaries.
+"""Business Unit: utilities; Status: current.
+
+Common DTOs for application layer and interface boundaries.
 
 This module provides Pydantic v2 DTOs for common data structures used across
 the application layer, replacing loose dataclasses and dict usage with

--- a/the_alchemiser/interfaces/schemas/enriched_data.py
+++ b/the_alchemiser/interfaces/schemas/enriched_data.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Order listing DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Order listing DTOs for The Alchemiser Trading System.
 
 This module contains DTOs for order listing operations, including
 open orders retrieval and order history.

--- a/the_alchemiser/interfaces/schemas/errors.py
+++ b/the_alchemiser/interfaces/schemas/errors.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Error reporting and notification DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Error reporting and notification DTOs for The Alchemiser Trading System.
 
 This module contains DTOs for error handling, reporting, and notification
 systems, moved from domain/types.py as part of the Pydantic migration.

--- a/the_alchemiser/interfaces/schemas/execution.py
+++ b/the_alchemiser/interfaces/schemas/execution.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Trading execution and result DTOs for The Alchemiser Trading System.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading execution and result DTOs for The Alchemiser Trading System.
 
 Pydantic v2 DTOs supporting trading execution lifecycle, order processing,
 websocket events, quotes, lambda events, and order history. Replaces legacy

--- a/the_alchemiser/interfaces/schemas/execution_summary.py
+++ b/the_alchemiser/interfaces/schemas/execution_summary.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Execution Summary DTOs for The Alchemiser Trading System.
+"""Business Unit: order execution/placement; Status: current.
+
+Execution Summary DTOs for The Alchemiser Trading System.
 
 This module provides structured DTOs for execution summaries, replacing
 dict[str, Any] usage in MultiStrategyExecutionResultDTO and other execution contexts.

--- a/the_alchemiser/interfaces/schemas/market_data.py
+++ b/the_alchemiser/interfaces/schemas/market_data.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Market Data DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Market Data DTOs for The Alchemiser Trading System.
 
 This module contains DTOs for market data operations, price queries,
 spread analysis, and market status information.

--- a/the_alchemiser/interfaces/schemas/operations.py
+++ b/the_alchemiser/interfaces/schemas/operations.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""General execution result DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+General execution result DTOs for The Alchemiser Trading System.
 
 This module contains DTOs for general operation results, including
 success/error handling patterns used across the trading system.

--- a/the_alchemiser/interfaces/schemas/orders.py
+++ b/the_alchemiser/interfaces/schemas/orders.py
@@ -1,4 +1,6 @@
-"""Order DTOs for application layer and interface boundaries.
+"""Business Unit: order execution/placement; Status: current.
+
+Order DTOs for application layer and interface boundaries.
 
 This module provides Pydantic v2 DTOs for order handling, replacing loose dicts
 and Any usages with strongly typed, validated structures. These DTOs are used

--- a/the_alchemiser/interfaces/schemas/portfolio_rebalancing.py
+++ b/the_alchemiser/interfaces/schemas/portfolio_rebalancing.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Portfolio Rebalancing DTOs for The Alchemiser Trading System.
+"""Business Unit: portfolio assessment & management; Status: current.
+
+Portfolio Rebalancing DTOs for The Alchemiser Trading System.
 
 This module provides Pydantic v2 DTOs for portfolio rebalancing operations,
 replacing dict/Any usage in portfolio services with strongly typed boundaries.

--- a/the_alchemiser/interfaces/schemas/positions.py
+++ b/the_alchemiser/interfaces/schemas/positions.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Position DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Position DTOs for The Alchemiser Trading System.
 
 This module contains DTOs for position data, portfolio summaries, and position analytics,
 providing type-safe interfaces for position management operations.

--- a/the_alchemiser/interfaces/schemas/reporting.py
+++ b/the_alchemiser/interfaces/schemas/reporting.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Reporting and dashboard DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Reporting and dashboard DTOs for The Alchemiser Trading System.
 
 This module contains DTOs for reporting, dashboard metrics, and email
 notifications, moved from domain/types.py as part of the Pydantic migration.

--- a/the_alchemiser/interfaces/schemas/smart_trading.py
+++ b/the_alchemiser/interfaces/schemas/smart_trading.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Smart Trading DTOs for The Alchemiser Trading System.
+"""Business Unit: order execution/placement; Status: current.
+
+Smart Trading DTOs for The Alchemiser Trading System.
 
 This module contains DTOs for advanced trading operations like smart order execution
 and comprehensive trading dashboard results.

--- a/the_alchemiser/interfaces/schemas/tracking.py
+++ b/the_alchemiser/interfaces/schemas/tracking.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Strategy Tracking DTOs for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Strategy Tracking DTOs for The Alchemiser Trading System.
 
 This module defines Pydantic v2 DTOs for strategy order tracking and execution
 telemetry, consumed by application/tracking/strategy_order_tracker.py.

--- a/the_alchemiser/lambda_handler.py
+++ b/the_alchemiser/lambda_handler.py
@@ -1,4 +1,6 @@
-"""AWS Lambda Handler for The Alchemiser Quantitative Trading System.
+"""Business Unit: utilities; Status: current.
+
+AWS Lambda Handler for The Alchemiser Quantitative Trading System.
 
 This module provides the entry point for running The Alchemiser trading system
 as an AWS Lambda function, enabling serverless execution and automated trading

--- a/the_alchemiser/main.py
+++ b/the_alchemiser/main.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Main Entry Point for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Main Entry Point for The Alchemiser Trading System.
 
 A clean, focused entry point for the multi-strategy quantitative trading system.
 Supports signal analysis and trading execution with dependency injection.

--- a/the_alchemiser/ports/__init__.py
+++ b/the_alchemiser/ports/__init__.py
@@ -1,4 +1,6 @@
-"""Core port definitions for application layer.
+"""Business Unit: utilities; Status: current.
+
+Core port definitions for application layer.
 
 These protocol interfaces describe the behaviour required by the trading
 application.  Concrete implementations live in the ``adapters`` package.

--- a/the_alchemiser/services/__init__.py
+++ b/the_alchemiser/services/__init__.py
@@ -1,4 +1,6 @@
-"""Service layer package.
+"""Business Unit: utilities; Status: current.
+
+Service layer package.
 
 Lightweight package initializer for the restructured service layer. The
 concrete services now live in dedicated subpackages:

--- a/the_alchemiser/services/account/__init__.py
+++ b/the_alchemiser/services/account/__init__.py
@@ -1,1 +1,2 @@
 # auto-created by perform_services_reorg
+"""Business Unit: utilities; Status: current."""

--- a/the_alchemiser/services/account/account_service.py
+++ b/the_alchemiser/services/account/account_service.py
@@ -1,3 +1,5 @@
+"""Business Unit: utilities; Status: current."""
+
 import logging
 from typing import Any, Literal, cast
 

--- a/the_alchemiser/services/account/account_utils.py
+++ b/the_alchemiser/services/account/account_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Account Data Utilities.
+"""Business Unit: utilities; Status: current.
+
+Account Data Utilities.
 
 This module provides helper functions for extracting and processing account information
 from data providers, including portfolio values, P&L calculations, and position data.

--- a/the_alchemiser/services/errors/__init__.py
+++ b/the_alchemiser/services/errors/__init__.py
@@ -1,4 +1,6 @@
-"""Error handling package for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Error handling package for The Alchemiser Trading System.
 
 This package provides consolidated error handling with:
 - TradingSystemErrorHandler as the single facade

--- a/the_alchemiser/services/errors/context.py
+++ b/the_alchemiser/services/errors/context.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Error context data structures for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Error context data structures for The Alchemiser Trading System.
 
 This module provides standardized error context data structures
 for consistent error reporting and tracking.

--- a/the_alchemiser/services/errors/decorators.py
+++ b/the_alchemiser/services/errors/decorators.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Exception translation decorators for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Exception translation decorators for The Alchemiser Trading System.
 
 This module provides decorators that only translate exceptions without logging.
 The logging is handled explicitly by orchestrators/services using the handler.

--- a/the_alchemiser/services/errors/error_handling.py
+++ b/the_alchemiser/services/errors/error_handling.py
@@ -1,4 +1,6 @@
-"""[DEPRECATED] Legacy error handling utilities.
+"""Business Unit: utilities; Status: current.
+
+[DEPRECATED] Legacy error handling utilities.
 
 This module has been deprecated and its functionality has been moved to:
 - TradingSystemErrorHandler (in handler.py) for centralized error handling

--- a/the_alchemiser/services/errors/error_monitoring.py
+++ b/the_alchemiser/services/errors/error_monitoring.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Error Monitoring and Alerting Framework for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Error Monitoring and Alerting Framework for The Alchemiser Trading System.
 
 This module implements Phase 3 of the error handling enhancement plan:
 - Error Metrics and Monitoring for real-time tracking

--- a/the_alchemiser/services/errors/error_recovery.py
+++ b/the_alchemiser/services/errors/error_recovery.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Error Recovery and Resilience Framework for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Error Recovery and Resilience Framework for The Alchemiser Trading System.
 
 This module implements Phase 2 of the error handling enhancement plan:
 - Automatic Error Recovery strategies

--- a/the_alchemiser/services/errors/error_reporter.py
+++ b/the_alchemiser/services/errors/error_reporter.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Centralized Error Reporter for Production Monitoring.
+"""Business Unit: utilities; Status: current.
+
+Centralized Error Reporter for Production Monitoring.
 
 This module provides structured error reporting for hands-off operation
 according to the error handling improvement plan.

--- a/the_alchemiser/services/errors/exceptions.py
+++ b/the_alchemiser/services/errors/exceptions.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Custom exception classes for The Alchemiser Quantitative Trading System.
+"""Business Unit: utilities; Status: current.
+
+Custom exception classes for The Alchemiser Quantitative Trading System.
 
 This module defines specific exception types for different failure scenarios
 to enable better error handling and debugging throughout the application.

--- a/the_alchemiser/services/errors/handler.py
+++ b/the_alchemiser/services/errors/handler.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Main error handler for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Main error handler for The Alchemiser Trading System.
 
 This module provides the single facade TradingSystemErrorHandler for all error handling,
 categorization, and detailed error reporting via email notifications.

--- a/the_alchemiser/services/errors/scope.py
+++ b/the_alchemiser/services/errors/scope.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Error scope context manager for The Alchemiser Trading System.
+"""Business Unit: utilities; Status: current.
+
+Error scope context manager for The Alchemiser Trading System.
 
 This module provides context managers for error handling with automatic logging.
 Renamed from ErrorContext to avoid naming collision.

--- a/the_alchemiser/services/market_data/__init__.py
+++ b/the_alchemiser/services/market_data/__init__.py
@@ -1,4 +1,6 @@
-"""Market data services package exports.
+"""Business Unit: utilities; Status: current.
+
+Market data services package exports.
 
 Prefer MarketDataService as the canonical typed service. StrategyMarketDataService
 is deprecated and will be removed once all callers are migrated.

--- a/the_alchemiser/services/market_data/market_data_client.py
+++ b/the_alchemiser/services/market_data/market_data_client.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Market Data Client.
+"""Business Unit: utilities; Status: current.
+
+Market Data Client.
 
 Handles market data REST API calls to Alpaca.
 Focused on data retrieval without trading operations.

--- a/the_alchemiser/services/market_data/market_data_service.py
+++ b/the_alchemiser/services/market_data/market_data_service.py
@@ -1,4 +1,6 @@
-"""Market Data Service - Enhanced market data operations with caching and validation.
+"""Business Unit: utilities; Status: current.
+
+Market Data Service - Enhanced market data operations with caching and validation.
 
 This service builds on the MarketDataRepository interface to provide:
 - Intelligent caching of market data

--- a/the_alchemiser/services/market_data/price_fetching_utils.py
+++ b/the_alchemiser/services/market_data/price_fetching_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Price Fetching Utilities.
+"""Business Unit: utilities; Status: current.
+
+Price Fetching Utilities.
 
 This module provides helper functions for price fetching operations,
 breaking down verbose price fetching logic into reusable components.

--- a/the_alchemiser/services/market_data/price_service.py
+++ b/the_alchemiser/services/market_data/price_service.py
@@ -1,4 +1,6 @@
-"""Modern price fetching service.
+"""Business Unit: utilities; Status: current.
+
+Modern price fetching service.
 
 Provides async/callback-based API for current price requests with
 graceful REST fallback when streaming is unavailable.

--- a/the_alchemiser/services/market_data/price_utils.py
+++ b/the_alchemiser/services/market_data/price_utils.py
@@ -1,4 +1,6 @@
-"""Price Utilities.
+"""Business Unit: utilities; Status: current.
+
+Price Utilities.
 
 This module provides helper functions for price handling and conversion operations.
 """

--- a/the_alchemiser/services/market_data/strategy_market_data_service.py
+++ b/the_alchemiser/services/market_data/strategy_market_data_service.py
@@ -1,4 +1,6 @@
-"""Strategy Market Data Service - Canonical MarketDataPort implementation.
+"""Business Unit: strategy & signal generation; Status: current.
+
+Strategy Market Data Service - Canonical MarketDataPort implementation.
 
 This service implements the canonical MarketDataPort protocol using typed domain
 models while providing backward-compatible DataFrame adapters for strategies.

--- a/the_alchemiser/services/market_data/streaming_service.py
+++ b/the_alchemiser/services/market_data/streaming_service.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Streaming Service.
+"""Business Unit: utilities; Status: current.
+
+Streaming Service.
 
 Handles real-time price subscriptions via WebSocket.
 Provides callback-based API for current price requests.

--- a/the_alchemiser/services/repository/__init__.py
+++ b/the_alchemiser/services/repository/__init__.py
@@ -1,1 +1,2 @@
 # auto-created by perform_services_reorg
+"""Business Unit: utilities; Status: current."""

--- a/the_alchemiser/services/repository/alpaca_manager.py
+++ b/the_alchemiser/services/repository/alpaca_manager.py
@@ -1,4 +1,6 @@
-"""Centralized Alpaca client management - Phase 1 of incremental improvements.
+"""Business Unit: utilities; Status: current.
+
+Centralized Alpaca client management - Phase 1 of incremental improvements.
 
 This module consolidates scattered Alpaca client usage into a single, well-managed class.
 It provides a transitional approach that:

--- a/the_alchemiser/services/shared/__init__.py
+++ b/the_alchemiser/services/shared/__init__.py
@@ -1,1 +1,2 @@
 # auto-created by perform_services_reorg
+"""Business Unit: utilities; Status: current."""

--- a/the_alchemiser/services/shared/cache_manager.py
+++ b/the_alchemiser/services/shared/cache_manager.py
@@ -1,4 +1,6 @@
-"""Cache management service with TTL support.
+"""Business Unit: utilities; Status: current.
+
+Cache management service with TTL support.
 
 Provides configurable caching with time-to-live per data type.
 """

--- a/the_alchemiser/services/shared/config_service.py
+++ b/the_alchemiser/services/shared/config_service.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Configuration Service.
+"""Business Unit: utilities; Status: current.
+
+Configuration Service.
 
 Handles loading and managing configuration for the trading system.
 Provides a clean interface for accessing configuration settings.

--- a/the_alchemiser/services/shared/retry_decorator.py
+++ b/the_alchemiser/services/shared/retry_decorator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Retry Decorator with Exponential Backoff.
+"""Business Unit: utilities; Status: current.
+
+Retry Decorator with Exponential Backoff.
 
 This module provides retry functionality with exponential backoff and jitter
 for robust error handling according to the error handling improvement plan.

--- a/the_alchemiser/services/shared/secrets_service.py
+++ b/the_alchemiser/services/shared/secrets_service.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Secrets Service.
+"""Business Unit: utilities; Status: current.
+
+Secrets Service.
 
 Handles credential retrieval for the trading system.
 Provides a clean interface for accessing API keys and other sensitive data.

--- a/the_alchemiser/services/shared/service_factory.py
+++ b/the_alchemiser/services/shared/service_factory.py
@@ -1,4 +1,7 @@
-"""Service factory using dependency injection."""
+"""Business Unit: utilities; Status: current.
+
+Service factory using dependency injection.
+"""
 
 from typing import cast
 

--- a/the_alchemiser/services/trading/__init__.py
+++ b/the_alchemiser/services/trading/__init__.py
@@ -1,1 +1,2 @@
 # auto-created by perform_services_reorg
+"""Business Unit: order execution/placement; Status: current."""

--- a/the_alchemiser/services/trading/order_service.py
+++ b/the_alchemiser/services/trading/order_service.py
@@ -1,4 +1,6 @@
-"""Enhanced Order Service.
+"""Business Unit: order execution/placement; Status: current.
+
+Enhanced Order Service.
 
 This service provides type-safe, validated order placement operations.
 It builds on top of the TradingRepository interface, adding:

--- a/the_alchemiser/services/trading/position_manager.py
+++ b/the_alchemiser/services/trading/position_manager.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Position Management Utilities.
+"""Business Unit: order execution/placement; Status: current.
+
+Position Management Utilities.
 
 This module provides helper functions for position management operations,
 including position validation, liquidation logic, and buying power checks.

--- a/the_alchemiser/services/trading/position_service.py
+++ b/the_alchemiser/services/trading/position_service.py
@@ -1,4 +1,6 @@
-"""Enhanced Position Service.
+"""Business Unit: order execution/placement; Status: current.
+
+Enhanced Position Service.
 
 This service provides type-safe position monitoring and management operations.
 It builds on top of the TradingRepository and MarketDataRepository interfaces, adding:

--- a/the_alchemiser/services/trading/trading_client_service.py
+++ b/the_alchemiser/services/trading/trading_client_service.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Trading Client Service.
+"""Business Unit: order execution/placement; Status: current.
+
+Trading Client Service.
 
 Handles trading operations via Alpaca API.
 Focused on order placement, account data, and positions.

--- a/the_alchemiser/services/trading/trading_service_manager.py
+++ b/the_alchemiser/services/trading/trading_service_manager.py
@@ -1,4 +1,7 @@
-"""Trading service facade aggregating order, position, market data, and account operations."""
+"""Business Unit: order execution/placement; Status: current.
+
+Trading service facade aggregating order, position, market data, and account operations.
+"""
 
 import logging
 from datetime import UTC, datetime

--- a/the_alchemiser/utils/__init__.py
+++ b/the_alchemiser/utils/__init__.py
@@ -1,4 +1,6 @@
-"""Utility functions and helpers for The Alchemiser Quantitative Trading System.
+"""Business Unit: utilities; Status: current.
+
+Utility functions and helpers for The Alchemiser Quantitative Trading System.
 
 This package contains various utility modules for trading operations,
 mathematical calculations, data handling, and system integration.

--- a/the_alchemiser/utils/common.py
+++ b/the_alchemiser/utils/common.py
@@ -1,4 +1,6 @@
-"""Common constants and enums shared across the trading system.
+"""Business Unit: utilities; Status: current.
+
+Common constants and enums shared across the trading system.
 
 This module provides shared enumeration types and constants used throughout
 the trading system to ensure consistency and type safety.

--- a/the_alchemiser/utils/num.py
+++ b/the_alchemiser/utils/num.py
@@ -1,4 +1,6 @@
-"""Numeric helper utilities.
+"""Business Unit: utilities; Status: current.
+
+Numeric helper utilities.
 
 Provides tolerant float comparison complying with project rule: never use
 direct float equality (== / !=). Use this helper in non-financial contexts;

--- a/the_alchemiser/utils/serialization.py
+++ b/the_alchemiser/utils/serialization.py
@@ -1,4 +1,6 @@
-"""Utility helpers for application-layer boundary serialization.
+"""Business Unit: utilities; Status: current.
+
+Utility helpers for application-layer boundary serialization.
 
 Provides safe, recursive conversion of Pydantic models, dataclasses, Decimals,
 and nested containers into JSON-friendly Python primitives while preserving


### PR DESCRIPTION
## Summary
- preserve existing module docstrings while prepending business unit and status headers
- document business unit conventions in README and Copilot instructions
- add script to update docstrings and generate business unit reports

## Testing
- `pre-commit run --files $(git diff --cached --name-only | tr '\n' ' ')`


------
https://chatgpt.com/codex/tasks/task_e_68b008ca42088333bdaedfb7c3083d02